### PR TITLE
Moved collection view datasource and delegate methods for About view controller into extensions.

### DIFF
--- a/ScienceJournal/UI/AboutViewController.swift
+++ b/ScienceJournal/UI/AboutViewController.swift
@@ -126,59 +126,62 @@ class AboutViewController: MaterialHeaderCollectionViewController {
   @objc private func closeButtonPressed() {
     dismiss(animated: true)
   }
+}
 
-  // MARK: - UICollectionViewDataSource
+// MARK: - UICollectionViewDataSource
 
-  override func collectionView(_ collectionView: UICollectionView,
-                               numberOfItemsInSection section: Int) -> Int {
-    return rows.count
-  }
-
-  override func collectionView(_ collectionView: UICollectionView,
-                               cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellIdentifier,
-                                                  for: indexPath)
-    if let textCell = cell as? MDCCollectionViewTextCell {
-      let rowData = rows[indexPath.row]
-      textCell.textLabel?.text = rowData.title
-      textCell.detailTextLabel?.text = rowData.description
-      textCell.accessibilityLabel = rowData.accessibilityLabel
-      textCell.accessibilityHint = rowData.accessibilityHint
-      textCell.isAccessibilityElement = true
-      textCell.accessibilityTraits = rowData.accessibilityTrait
+extension AboutViewController {
+    override func collectionView(_ collectionView: UICollectionView,
+                                 numberOfItemsInSection section: Int) -> Int {
+        return rows.count
     }
-    return cell
-  }
-
-  override func collectionView(_ collectionView: UICollectionView,
-                               cellHeightAt indexPath: IndexPath) -> CGFloat {
-    let rowData = rows[indexPath.row]
-    if rowData.description != nil {
-      return MDCCellDefaultTwoLineHeight
-    } else {
-      return MDCCellDefaultOneLineHeight
+    
+    override func collectionView(_ collectionView: UICollectionView,
+                                 cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellIdentifier,
+                                                      for: indexPath)
+        if let textCell = cell as? MDCCollectionViewTextCell {
+            let rowData = rows[indexPath.row]
+            textCell.textLabel?.text = rowData.title
+            textCell.detailTextLabel?.text = rowData.description
+            textCell.accessibilityLabel = rowData.accessibilityLabel
+            textCell.accessibilityHint = rowData.accessibilityHint
+            textCell.isAccessibilityElement = true
+            textCell.accessibilityTraits = rowData.accessibilityTrait
+        }
+        return cell
     }
-  }
-
-  // MARK: - UICollectionViewDelegate
-
-  override func collectionView(_ collectionView: UICollectionView,
-                               didSelectItemAt indexPath: IndexPath) {
-    let rowData = rows[indexPath.row]
-    switch rowData {
-    case .website, .privacy, .terms:
-      if let stringURL = rowData.description, let url = URL(string: stringURL) {
-        UIApplication.shared.open(url)
-      }
-      break
-    case .licenses:
-      navigationController?.pushViewController(
-          LicensesViewController(analyticsReporter: analyticsReporter),
-          animated: true)
-      break
-    default:
-      return
+    
+    override func collectionView(_ collectionView: UICollectionView,
+                                 cellHeightAt indexPath: IndexPath) -> CGFloat {
+        let rowData = rows[indexPath.row]
+        if rowData.description != nil {
+            return MDCCellDefaultTwoLineHeight
+        } else {
+            return MDCCellDefaultOneLineHeight
+        }
     }
-  }
+}
 
+// MARK: - UICollectionViewDelegate
+
+extension AboutViewController {
+    override func collectionView(_ collectionView: UICollectionView,
+                                 didSelectItemAt indexPath: IndexPath) {
+        let rowData = rows[indexPath.row]
+        switch rowData {
+        case .website, .privacy, .terms:
+            if let stringURL = rowData.description, let url = URL(string: stringURL) {
+                UIApplication.shared.open(url)
+            }
+            break
+        case .licenses:
+            navigationController?.pushViewController(
+                LicensesViewController(analyticsReporter: analyticsReporter),
+                animated: true)
+            break
+        default:
+            return
+        }
+    }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Science Journal iOS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/google/science-journal-ios/blob/master/CONTRIBUTING.md)

### Motivation and Context
In order to improve code quality, I decided to move the collection view data source and delegate methods into view controller's extension as it's a good common practice.

### Description
There is no new code and existing code is not changed, just moved around. 
