### PR TITLE
Removed unnecessary unregistering NSNotificationCenter observers in deinit

### DIFF
--- a/ScienceJournal/CaptureSession/AudioCapture.swift
+++ b/ScienceJournal/CaptureSession/AudioCapture.swift
@@ -77,10 +77,6 @@ class AudioCapture: NSObject, AVCaptureAudioDataOutputSampleBufferDelegate {
                                            object: nil)
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   /// Prepares the audio capture to run, checks for microphone permission, and starts running the
   /// audio capture if it has microphone permission. After calling start, it must be balanced with a
   /// call to endUsing when finished using the audio capture.

--- a/ScienceJournal/CaptureSession/CaptureSessionInterruptionObserver.swift
+++ b/ScienceJournal/CaptureSession/CaptureSessionInterruptionObserver.swift
@@ -39,10 +39,6 @@ class CaptureSessionInterruptionObserver {
 
   // MARK: - Public
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   // MARK: - Private
 
   /// Use `shared`.

--- a/ScienceJournal/Chart/ChartController.swift
+++ b/ScienceJournal/Chart/ChartController.swift
@@ -331,10 +331,6 @@ class ChartController: NSObject, ChartViewDelegate, UIScrollViewDelegate {
                                            object: nil)
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   /// Loads data and resets the view to show the entire dataset.
   ///
   /// - Parameters:

--- a/ScienceJournal/Metadata/ExperimentUpdateManager.swift
+++ b/ScienceJournal/Metadata/ExperimentUpdateManager.swift
@@ -63,10 +63,6 @@ class ExperimentUpdateManager {
         object: nil)
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   /// Adds the given object as a listener to experiment changes. Listener must conform to
   /// ExperimentUpdateListener to actually recieve updates. Maintains a weak reference to listeners.
   ///

--- a/ScienceJournal/Metadata/MetadataManager.swift
+++ b/ScienceJournal/Metadata/MetadataManager.swift
@@ -197,10 +197,6 @@ public class MetadataManager {
         object: nil)
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   /// Returns the assets directory URL for a specific experiment.
   ///
   /// - Parameter experiment: An experiment.

--- a/ScienceJournal/Sensors/AudioSensor.swift
+++ b/ScienceJournal/Sensors/AudioSensor.swift
@@ -71,10 +71,6 @@ class AudioSensor: Sensor {
                                            object: nil)
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override func start() {
     if state != .interrupted {
       state = .loading

--- a/ScienceJournal/Sensors/BrightnessSensor.swift
+++ b/ScienceJournal/Sensors/BrightnessSensor.swift
@@ -129,7 +129,6 @@ class BrightnessSensor: Sensor, AVCaptureVideoDataOutputSampleBufferDelegate {
   }
 
   deinit {
-    NotificationCenter.default.removeObserver(self)
     CameraCaptureSessionManager.shared.removeUser(self)
   }
 

--- a/ScienceJournal/UI/AddTrialNoteViewController.swift
+++ b/ScienceJournal/UI/AddTrialNoteViewController.swift
@@ -79,10 +79,6 @@ class AddTrialNoteViewController: ScienceJournalViewController, UITextFieldDeleg
 
   // MARK: - Public
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override func viewDidLoad() {
     super.viewDidLoad()
 

--- a/ScienceJournal/UI/AppFlowViewController.swift
+++ b/ScienceJournal/UI/AppFlowViewController.swift
@@ -159,10 +159,6 @@ class AppFlowViewController: UIViewController {
     fatalError("init(coder:) is not supported")
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override func viewDidLoad() {
     super.viewDidLoad()
 

--- a/ScienceJournal/UI/CameraViewController.swift
+++ b/ScienceJournal/UI/CameraViewController.swift
@@ -115,10 +115,6 @@ open class CameraViewController: ScienceJournalViewController, DrawerItemViewCon
 
   // MARK: - Public
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override open func viewDidLoad() {
     super.viewDidLoad()
 

--- a/ScienceJournal/UI/DrawerViewController.swift
+++ b/ScienceJournal/UI/DrawerViewController.swift
@@ -201,8 +201,6 @@ open class DrawerViewController: UIViewController, DrawerViewDelegate {
     for case let listener as DrawerPositionListener in drawerItems.viewControllers {
       removeDrawerPositionListener(listener)
     }
-
-    NotificationCenter.default.removeObserver(self)
   }
 
   required public init?(coder aDecoder: NSCoder) {

--- a/ScienceJournal/UI/EditExperimentViewController.swift
+++ b/ScienceJournal/UI/EditExperimentViewController.swift
@@ -105,10 +105,6 @@ class EditExperimentViewController: MaterialHeaderViewController, EditExperiment
     fatalError("init(coder:) is not supported")
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override func viewDidLoad() {
     super.viewDidLoad()
     view.backgroundColor = UIColor(red: 0.937, green: 0.933, blue: 0.933, alpha: 1.0)

--- a/ScienceJournal/UI/ExperimentCoordinatorViewController.swift
+++ b/ScienceJournal/UI/ExperimentCoordinatorViewController.swift
@@ -264,7 +264,6 @@ class ExperimentCoordinatorViewController: MaterialHeaderViewController, DrawerP
 
   deinit {
     drawerVC?.removeDrawerPositionListener(self)
-    NotificationCenter.default.removeObserver(self)
   }
 
   override func viewDidLoad() {

--- a/ScienceJournal/UI/ExperimentsListViewController.swift
+++ b/ScienceJournal/UI/ExperimentsListViewController.swift
@@ -218,10 +218,6 @@ class ExperimentsListViewController: MaterialHeaderViewController, ExperimentSta
     fatalError("init(coder:) is not supported")
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override func viewDidLoad() {
     super.viewDidLoad()
 

--- a/ScienceJournal/UI/KeyboardObserver.swift
+++ b/ScienceJournal/UI/KeyboardObserver.swift
@@ -82,10 +82,6 @@ class KeyboardObserver {
         object: nil)
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   /// Returns animation curve stored in the user info of a UI keyboard or keyboard observer
   /// notification.
   ///

--- a/ScienceJournal/UI/NotesView.swift
+++ b/ScienceJournal/UI/NotesView.swift
@@ -133,10 +133,6 @@ class NotesView: UIView {
     setSendButtonStyle(.toolbar)
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override func safeAreaInsetsDidChange() {
     updateActionBarHeight()
     updateTextViewTextContainerInset()

--- a/ScienceJournal/UI/NotesViewController.swift
+++ b/ScienceJournal/UI/NotesViewController.swift
@@ -52,10 +52,6 @@ open class NotesViewController: ScienceJournalViewController, DrawerItemViewCont
 
   // MARK: - Public
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override open func loadView() {
     view = NotesView()
     notesView.textView.delegate = self

--- a/ScienceJournal/UI/ObserveViewController.swift
+++ b/ScienceJournal/UI/ObserveViewController.swift
@@ -228,10 +228,6 @@ open class ObserveViewController: ScienceJournalCollectionViewController, ChartC
     fatalError("init(coder:) is not supported")
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   /// Adds the note to all recording charts.
   ///
   /// - Parameter note: A display note.

--- a/ScienceJournal/UI/PermissionsGuideViewController.swift
+++ b/ScienceJournal/UI/PermissionsGuideViewController.swift
@@ -113,10 +113,6 @@ class PermissionsGuideViewController: OnboardingViewController {
     fatalError("init(coder:) is not supported")
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override var preferredStatusBarStyle: UIStatusBarStyle {
     return .lightContent
   }

--- a/ScienceJournal/UI/PhotoLibraryViewController.swift
+++ b/ScienceJournal/UI/PhotoLibraryViewController.swift
@@ -112,10 +112,6 @@ open class PhotoLibraryViewController: ScienceJournalViewController, UICollectio
     fatalError("init(coder:) has not been implemented")
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override open func viewDidLoad() {
     super.viewDidLoad()
 

--- a/ScienceJournal/UI/PictureCardCell.swift
+++ b/ScienceJournal/UI/PictureCardCell.swift
@@ -45,10 +45,6 @@ class PictureCardCell: FrameLayoutMaterialCardCell {
     addNotificationObservers()
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override func layoutSubviews() {
     super.layoutSubviews()
 

--- a/ScienceJournal/UI/PictureDetailViewController.swift
+++ b/ScienceJournal/UI/PictureDetailViewController.swift
@@ -121,10 +121,6 @@ class PictureDetailViewController:
     fatalError("init(coder:) is not supported")
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override func viewDidLoad() {
     super.viewDidLoad()
     view.backgroundColor = .black

--- a/ScienceJournal/UI/RecordingAnimatedView.swift
+++ b/ScienceJournal/UI/RecordingAnimatedView.swift
@@ -54,10 +54,6 @@ class RecordingAnimatedView: UIView {
     registerForNotifications()
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   /// Starts the recording animation.
   func startAnimating() {
     // Dispatching to main works around a problem where the animations will not start if they are

--- a/ScienceJournal/UI/RenameViewController.swift
+++ b/ScienceJournal/UI/RenameViewController.swift
@@ -67,10 +67,6 @@ class RenameViewController: ScienceJournalViewController, UITextFieldDelegate {
 
   // MARK: - Public
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override func viewDidLoad() {
     super.viewDidLoad()
     view.backgroundColor = .white

--- a/ScienceJournal/UI/TextNoteDetailViewController.swift
+++ b/ScienceJournal/UI/TextNoteDetailViewController.swift
@@ -73,10 +73,6 @@ class TextNoteDetailViewController: MaterialHeaderViewController, NoteDetailCont
     fatalError("init(coder:) is not supported")
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override func viewDidLoad() {
     super.viewDidLoad()
     view.backgroundColor = .white

--- a/ScienceJournal/UI/TrialCardCell.swift
+++ b/ScienceJournal/UI/TrialCardCell.swift
@@ -49,10 +49,6 @@ class TrialCardCell: AutoLayoutMaterialCardCell {
     addNotificationObservers()
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override func prepareForReuse() {
     recordedTrialCardView.trialCardNotesView.removeAllNotes()
   }

--- a/ScienceJournal/UI/TrialCardNoteViewPool.swift
+++ b/ScienceJournal/UI/TrialCardNoteViewPool.swift
@@ -34,10 +34,6 @@ class TrialCardNoteViewPool {
                                            object: nil)
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   /// Creates or returns a cached text note card view to be used for a trial card notes view.
   ///
   /// - Parameters:

--- a/ScienceJournal/UI/TrialDetailViewController.swift
+++ b/ScienceJournal/UI/TrialDetailViewController.swift
@@ -303,10 +303,6 @@ class TrialDetailViewController: MaterialHeaderViewController,
     fatalError("init(coder:) is not supported")
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override func viewDidLoad() {
     super.viewDidLoad()
 

--- a/ScienceJournal/UI/TriggerEditViewController.swift
+++ b/ScienceJournal/UI/TriggerEditViewController.swift
@@ -168,10 +168,6 @@ class TriggerEditViewController: MaterialHeaderViewController, TriggerEditDelega
     fatalError("init(coder:) is not supported")
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override func viewDidLoad() {
     super.viewDidLoad()
     accessibilityViewIsModal = true

--- a/ScienceJournal/UI/UserFlowViewController.swift
+++ b/ScienceJournal/UI/UserFlowViewController.swift
@@ -153,10 +153,6 @@ class UserFlowViewController: UIViewController, ExperimentsListViewControllerDel
     fatalError("init(coder:) is not supported")
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override open func viewDidLoad() {
     super.viewDidLoad()
 


### PR DESCRIPTION
<!-- Thanks for contributing to Science Journal iOS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/google/science-journal-ios/blob/master/CONTRIBUTING.md)

### Motivation and Context
Since iOS 9.0 it is no longer necessary for an NSNotificationCenter observer to un-register itself when being deallocated:
[Foundation Release Notes (macOS 10.12 and Earlier)](https://developer.apple.com/library/archive/releasenotes/Foundation/RN-FoundationOlderNotes/index.html#10_11NotificationCenter)

### Description
Removed unnecessary unregistering NSNotificationCenter observers in deinit.