### PR TITLE
RelativeScaleAnimationView crash with div by zero

### DIFF
--- a/ScienceJournal/Chart/ChartController.swift
+++ b/ScienceJournal/Chart/ChartController.swift
@@ -481,7 +481,7 @@ class ChartController: NSObject, ChartViewDelegate, UIScrollViewDelegate {
     let increment = axisLabels[1] - axisLabels[0]
 
     // increment and increment + 1 are used as denominators.
-    guard increment > 0, increment + 1 > 0 else { return 0 }
+    guard increment > 0 else { return 0 }
 
     let startIndex = Int(floor((minShown - axisLabels[0]) / increment + 1))
     let endIndex = Int(ceil((maxShown - lastAxisLabel) / increment)) + axisLabels.count - 1

--- a/ScienceJournal/Chart/ChartController.swift
+++ b/ScienceJournal/Chart/ChartController.swift
@@ -479,7 +479,9 @@ class ChartController: NSObject, ChartViewDelegate, UIScrollViewDelegate {
     }
 
     let increment = axisLabels[1] - axisLabels[0]
-    guard increment > 0 else { return 0 }
+
+    // increment and increment + 1 are used as denominators.
+    guard increment > 0, increment + 1 > 0 else { return 0 }
 
     let startIndex = Int(floor((minShown - axisLabels[0]) / increment + 1))
     let endIndex = Int(ceil((maxShown - lastAxisLabel) / increment)) + axisLabels.count - 1

--- a/ScienceJournal/UI/RelativeScaleAnimationView.swift
+++ b/ScienceJournal/UI/RelativeScaleAnimationView.swift
@@ -21,11 +21,13 @@ class RelativeScaleAnimationView: ImageAnimationView {
 
   override func imageIndex(forValue value: Double, minValue: Double, maxValue: Double) -> Int {
     // To calculate a relative scale, there must be a valid range.
-    guard maxValue - minValue > 0 else {
+
+    let denominator = maxValue - minValue
+    guard fabs(denominator) > Double.ulpOfOne else {
       return 0
     }
 
-    var valuePercentage = (value - minValue) / (maxValue - minValue)
+    var valuePercentage = (value - minValue) / denominator
     valuePercentage = max(min(valuePercentage, 1.0), 0)
     let index = Int(floor(valuePercentage * Double(images.count)))
     // If percentage is 1.0 index can be beyond count so clamp it.

--- a/ScienceJournal/UI/RelativeScaleAnimationView.swift
+++ b/ScienceJournal/UI/RelativeScaleAnimationView.swift
@@ -23,7 +23,7 @@ class RelativeScaleAnimationView: ImageAnimationView {
     // To calculate a relative scale, there must be a valid range.
 
     let denominator = maxValue - minValue
-    guard fabs(denominator) > Double.ulpOfOne else {
+    guard denominator > Double.ulpOfOne else {
       return 0
     }
 


### PR DESCRIPTION
### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/google/science-journal-ios/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/google/science-journal-ios/blob/master/CHANGE_LIMITATIONS.md)

### Motivation and Context
Getting a couple crashes due to div by zero. 

### Description
Instead of comparing to 0 we compare to ulpOfOne, since these are doubles and computer math is hard 🙃