### PR TITLE
Magnetometer values can be outside of reality

### DIFF
--- a/ScienceJournal.xcodeproj/project.pbxproj
+++ b/ScienceJournal.xcodeproj/project.pbxproj
@@ -2839,9 +2839,9 @@
 				TargetAttributes = {
 					68EBA6D91E20421E0089FF7F = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = EQHXZ8M8AV;
+						DevelopmentTeam = 7H9A787KDD;
 						LastSwiftMigration = 1000;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 0;
@@ -3755,8 +3755,11 @@
 			baseConfigurationReference = D65BB81A86250B67E7CA196C /* Pods-ScienceJournal.adhoc.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = logo_science_journal_dogfood_color;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0;
+				DEVELOPMENT_TEAM = 7H9A787KDD;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$PODS_CONFIGURATION_BUILD_DIR/MDFInternationalization\"",
@@ -3793,9 +3796,10 @@
 					"\"SystemConfiguration\"",
 					"-l\"iconv\"",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournal;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournalTaq;
 				PRODUCT_MODULE_NAME = third_party_sciencejournal_ios_ScienceJournalOpen;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT = 0;
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
 				SWIFT_VERSION = 4.2;
@@ -3920,8 +3924,10 @@
 			baseConfigurationReference = 93AFC6D21C987695548ADC66 /* Pods-ScienceJournal.dogfood.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = logo_science_journal_dogfood_color;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0;
-				DEVELOPMENT_TEAM = EQHXZ8M8AV;
+				DEVELOPMENT_TEAM = 7H9A787KDD;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$PODS_CONFIGURATION_BUILD_DIR/MDFInternationalization\"",
@@ -3977,10 +3983,10 @@
 					"-l\"iconv\"",
 				);
 				OTHER_SWIFT_FLAGS = "-DSCIENCEJOURNAL_DOGFOOD_BUILD";
-				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournal;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournalTaq;
 				PRODUCT_MODULE_NAME = third_party_sciencejournal_ios_ScienceJournalOpen;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "Science Journal Dev";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT = 0;
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
 				SWIFT_VERSION = 4.2;
@@ -4164,9 +4170,11 @@
 			baseConfigurationReference = 81B6ADB3C8B55839B4C266D2 /* Pods-ScienceJournal.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = logo_science_journal_dogfood_color;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = EQHXZ8M8AV;
+				DEVELOPMENT_TEAM = 7H9A787KDD;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$PODS_CONFIGURATION_BUILD_DIR/MDFInternationalization\"",
@@ -4223,11 +4231,11 @@
 					"-l\"iconv\"",
 				);
 				OTHER_SWIFT_FLAGS = "-DSCIENCEJOURNAL_ENABLE_DEBUG -DSCIENCEJOURNAL_DEV_BUILD";
-				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournal;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournalTaq;
 				PRODUCT_MODULE_NAME = third_party_sciencejournal_ios_ScienceJournalOpen;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "Science Journal Dev";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT = 3;
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
 				SWIFT_VERSION = 4.2;
@@ -4241,8 +4249,10 @@
 			baseConfigurationReference = 1F4A9ECB04F0828D44D2C26D /* Pods-ScienceJournal.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = logo_science_journal_color;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0;
-				DEVELOPMENT_TEAM = EQHXZ8M8AV;
+				DEVELOPMENT_TEAM = 7H9A787KDD;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$PODS_CONFIGURATION_BUILD_DIR/MDFInternationalization\"",
@@ -4279,10 +4289,10 @@
 					"\"SystemConfiguration\"",
 					"-l\"iconv\"",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournal;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournalTaq;
 				PRODUCT_MODULE_NAME = third_party_sciencejournal_ios_ScienceJournalOpen;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "Science Journal Dev";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT = 0;
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
 				SWIFT_VERSION = 4.2;

--- a/ScienceJournal.xcodeproj/project.pbxproj
+++ b/ScienceJournal.xcodeproj/project.pbxproj
@@ -2839,9 +2839,9 @@
 				TargetAttributes = {
 					68EBA6D91E20421E0089FF7F = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = 7H9A787KDD;
+						DevelopmentTeam = EQHXZ8M8AV;
 						LastSwiftMigration = 1000;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 0;
@@ -3755,11 +3755,8 @@
 			baseConfigurationReference = D65BB81A86250B67E7CA196C /* Pods-ScienceJournal.adhoc.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = logo_science_journal_dogfood_color;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0;
-				DEVELOPMENT_TEAM = 7H9A787KDD;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$PODS_CONFIGURATION_BUILD_DIR/MDFInternationalization\"",
@@ -3796,10 +3793,9 @@
 					"\"SystemConfiguration\"",
 					"-l\"iconv\"",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournalTaq;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournal;
 				PRODUCT_MODULE_NAME = third_party_sciencejournal_ios_ScienceJournalOpen;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT = 0;
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
 				SWIFT_VERSION = 4.2;
@@ -3924,10 +3920,8 @@
 			baseConfigurationReference = 93AFC6D21C987695548ADC66 /* Pods-ScienceJournal.dogfood.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = logo_science_journal_dogfood_color;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0;
-				DEVELOPMENT_TEAM = 7H9A787KDD;
+				DEVELOPMENT_TEAM = EQHXZ8M8AV;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$PODS_CONFIGURATION_BUILD_DIR/MDFInternationalization\"",
@@ -3983,10 +3977,10 @@
 					"-l\"iconv\"",
 				);
 				OTHER_SWIFT_FLAGS = "-DSCIENCEJOURNAL_DOGFOOD_BUILD";
-				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournalTaq;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournal;
 				PRODUCT_MODULE_NAME = third_party_sciencejournal_ios_ScienceJournalOpen;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "Science Journal Dev";
 				SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT = 0;
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
 				SWIFT_VERSION = 4.2;
@@ -4170,11 +4164,9 @@
 			baseConfigurationReference = 81B6ADB3C8B55839B4C266D2 /* Pods-ScienceJournal.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = logo_science_journal_dogfood_color;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = 7H9A787KDD;
+				DEVELOPMENT_TEAM = EQHXZ8M8AV;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$PODS_CONFIGURATION_BUILD_DIR/MDFInternationalization\"",
@@ -4231,11 +4223,11 @@
 					"-l\"iconv\"",
 				);
 				OTHER_SWIFT_FLAGS = "-DSCIENCEJOURNAL_ENABLE_DEBUG -DSCIENCEJOURNAL_DEV_BUILD";
-				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournalTaq;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournal;
 				PRODUCT_MODULE_NAME = third_party_sciencejournal_ios_ScienceJournalOpen;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "Science Journal Dev";
 				SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT = 3;
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
 				SWIFT_VERSION = 4.2;
@@ -4249,10 +4241,8 @@
 			baseConfigurationReference = 1F4A9ECB04F0828D44D2C26D /* Pods-ScienceJournal.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = logo_science_journal_color;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0;
-				DEVELOPMENT_TEAM = 7H9A787KDD;
+				DEVELOPMENT_TEAM = EQHXZ8M8AV;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$PODS_CONFIGURATION_BUILD_DIR/MDFInternationalization\"",
@@ -4289,10 +4279,10 @@
 					"\"SystemConfiguration\"",
 					"-l\"iconv\"",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournalTaq;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournal;
 				PRODUCT_MODULE_NAME = third_party_sciencejournal_ios_ScienceJournalOpen;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "Science Journal Dev";
 				SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT = 0;
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
 				SWIFT_VERSION = 4.2;

--- a/ScienceJournal/Sensors/MagnetometerSensor.swift
+++ b/ScienceJournal/Sensors/MagnetometerSensor.swift
@@ -62,12 +62,10 @@ class MagnetometerSensor: MotionSensor {
   }
 
   override func callListenerBlocksWithData(atMilliseconds milliseconds: Int64) {
-    guard let magneticField =
-        MagnetometerSensor.motionManager.deviceMotion?.magneticField.field else { return }
+    guard let magneticField = MagnetometerSensor.motionManager.deviceMotion?.magneticField.field,
+      isValid(magneticFieldReading: magneticField)
+    else { return }
 
-    guard isValid(magneticFieldReading: magneticField) else {
-      return
-    }
     // The magnetic strength is the square root of the sum of the squares of the values in X, Y
     // and Z.
     var magneticStrength =
@@ -75,7 +73,7 @@ class MagnetometerSensor: MotionSensor {
 
     // Typical white dwarf stars have a magnetic field of around 100 Tesla (100,000,000 µT), so
     // let's cap our values there.
-    // Note: not a good idea to get close enough to measure a white dwarf star.
+    // Note: Not a good idea to get close enough to measure a white dwarf star.
     if magneticStrength > whiteDwarfMagneticFieldStrength {
       magneticStrength = whiteDwarfMagneticFieldStrength
     }
@@ -87,7 +85,7 @@ class MagnetometerSensor: MotionSensor {
   /// Sometimes we can get junk readings. The easiest way to check is to compare all axes
   /// to make sure their individual readings aren't extremely far apart.
   private func isValid(magneticFieldReading field: CMMagneticField) -> Bool {
-    // Axes can be negative
+    // Axes can be negative.
     let x = abs(field.x)
     let y = abs(field.y)
     let z = abs(field.z)
@@ -98,7 +96,7 @@ class MagnetometerSensor: MotionSensor {
     // If we can multiply the smallest value by 10,000 and it's larger than the largest value, that means
     // our values are relatively close together, so they are likely to be valid. By testing various
     // axes, we've been able to deduce that the absolute value difference between axes is typically
-    // less than a factor of 10000.
+    // less than a factor of 10,000.
     if smallestAxisValue * 10_000 > largestAxisValue {
       return true
     }

--- a/ScienceJournal/Sensors/MagnetometerSensor.swift
+++ b/ScienceJournal/Sensors/MagnetometerSensor.swift
@@ -63,7 +63,7 @@ class MagnetometerSensor: MotionSensor {
 
   override func callListenerBlocksWithData(atMilliseconds milliseconds: Int64) {
     guard let magneticField = MagnetometerSensor.motionManager.deviceMotion?.magneticField.field,
-      isValid(magneticFieldReading: magneticField)
+        isValid(magneticFieldReading: magneticField)
     else { return }
 
     // The magnetic strength is the square root of the sum of the squares of the values in X, Y

--- a/ScienceJournal/Sensors/MagnetometerSensor.swift
+++ b/ScienceJournal/Sensors/MagnetometerSensor.swift
@@ -95,7 +95,7 @@ class MagnetometerSensor: MotionSensor {
     let largestAxisValue = max(max(x, y), y)
     let smallestAxisValue = min(min(x, y), z)
 
-    // If we can multiple the smallest value and it's larger than the largest value, that means
+    // If we can multiply the smallest value by 10,000 and it's larger than the largest value, that means
     // our values are relatively close together, so they are likely to be valid. By testing various
     // axes, we've been able to deduce that the absolute value difference between axes is typically
     // less than a factor of 10000.

--- a/ScienceJournal/Sensors/MagnetometerSensor.swift
+++ b/ScienceJournal/Sensors/MagnetometerSensor.swift
@@ -85,7 +85,7 @@ class MagnetometerSensor: MotionSensor {
   }
 
   /// Sometimes we can get junk readings. The easiest way to check is to compare all axes
-  /// to make sure their individual readings are extremely far apart.
+  /// to make sure their individual readings aren't extremely far apart.
   private func isValid(magneticFieldReading field: CMMagneticField) -> Bool {
     // Axes can be negative
     let x = abs(field.x)

--- a/ScienceJournal/Sensors/MagnetometerSensor.swift
+++ b/ScienceJournal/Sensors/MagnetometerSensor.swift
@@ -99,7 +99,7 @@ class MagnetometerSensor: MotionSensor {
     // our values are relatively close together, so they are likely to be valid. By testing various
     // axes, we've been able to deduce that the absolute value difference between axes is typically
     // less than a factor of 10000.
-    if smallestAxisValue * 10000 > largestAxisValue {
+    if smallestAxisValue * 10_000 > largestAxisValue {
       return true
     }
     return false


### PR DESCRIPTION
Sometimes we can get erroneous values from the magnetometer. This PR:
- Caps the values possible to the magnetic strength of your average white dwarf star
- Checks to ensure the magnetic axes are within a factor of 10,000 of each other- a sign of bad data is one axis can shoot up to well over 1,000,000,000 of the others, which isn't correct.

This can cause crashing, but also weird graph data:
![File](https://user-images.githubusercontent.com/1304821/55926768-83d67400-5bc7-11e9-840b-5b0339725f8d.jpg)

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/google/science-journal-ios/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/google/science-journal-ios/blob/master/CHANGE_LIMITATIONS.md)


