### PR TITLE
Int() can overflow, use fail-able initializer

### DIFF
--- a/ScienceJournal/Chart/ChartController.swift
+++ b/ScienceJournal/Chart/ChartController.swift
@@ -481,9 +481,17 @@ class ChartController: NSObject, ChartViewDelegate, UIScrollViewDelegate {
     let increment = axisLabels[1] - axisLabels[0]
     guard increment > 0 else { return 0 }
 
-    let startIndex = Int(floor((minShown - axisLabels[0]) / increment + 1))
-    let endIndex = Int(ceil((maxShown - lastAxisLabel) / increment)) + axisLabels.count - 1
-    return endIndex - startIndex
+
+    let startIndex = Int(exactly: floor((minShown - axisLabels[0]) / Double(increment + 1)))
+    let endIndexCeil = ceil((maxShown - lastAxisLabel) / increment)
+    let endIndex = Int(exactly: endIndexCeil + Double(axisLabels.count - 1))
+
+    if let startIndex = startIndex, let endIndex = endIndex {
+      // If percentage is 1.0 index can be beyond count so clamp it.
+      return endIndex - startIndex
+    } else {
+      return 0
+    }
   }
 
   /// Returns the closest data point to a given timestamp.
@@ -581,7 +589,10 @@ class ChartController: NSObject, ChartViewDelegate, UIScrollViewDelegate {
 
     // The number of data points that exist for each display point. The resulting number of view
     // points will be double this number since we record a min and a max.
-    let pointsPerDisplayPoint = Int(ceil(CGFloat(dataPoints.count) / chartView.bounds.width))
+    let points = Int(exactly: ceil(CGFloat(dataPoints.count) / chartView.bounds.width))
+    guard let pointsPerDisplayPoint = points else {
+      return nil
+    }
 
     var nextMax: DataPoint?
     var nextMin: DataPoint?

--- a/ScienceJournal/Chart/ChartController.swift
+++ b/ScienceJournal/Chart/ChartController.swift
@@ -487,7 +487,6 @@ class ChartController: NSObject, ChartViewDelegate, UIScrollViewDelegate {
     let endIndex = Int(exactly: endIndexCeil + Double(axisLabels.count - 1))
 
     if let startIndex = startIndex, let endIndex = endIndex {
-      // If percentage is 1.0 index can be beyond count so clamp it.
       return endIndex - startIndex
     } else {
       return 0

--- a/ScienceJournal/Recording/ZoomPresenter.swift
+++ b/ScienceJournal/Recording/ZoomPresenter.swift
@@ -82,11 +82,15 @@ class ZoomPresenter {
       return currentTier
     }
 
-    // Note: On Android this code rounds instead of floors. Rounding up should always produce a tier
-    // with insufficient data points. Have not figured out the descrepency with Android code.
-    let actualTier = Int(floor(idealTier))
-    let maxTier = Int(zoomPresenterTierCount) - 1
-    return (0...maxTier).clamp(actualTier)
+    let actualTier = Int(exactly: floor(idealTier))
+    if let actualTier = actualTier {
+      // Note: On Android this code rounds instead of floors. Rounding up should always produce a
+      // tier with insufficient data points. Have not figured out the descrepency with Android code.
+      let maxTier = zoomPresenterTierCount - 1
+      return (0...maxTier).clamp(actualTier)
+    } else {
+      return currentTier
+    }
   }
 
   /// Returns an ideal tier as a fractional value.

--- a/ScienceJournal/Recording/ZoomPresenter.swift
+++ b/ScienceJournal/Recording/ZoomPresenter.swift
@@ -82,10 +82,10 @@ class ZoomPresenter {
       return currentTier
     }
 
+    // Note: On Android this code rounds instead of floors. Rounding up should always produce a tier
+    // with insufficient data points. Have not figured out the descrepency with Android code.
     let actualTier = Int(exactly: floor(idealTier))
     if let actualTier = actualTier {
-      // Note: On Android this code rounds instead of floors. Rounding up should always produce a
-      // tier with insufficient data points. Have not figured out the descrepency with Android code.
       let maxTier = zoomPresenterTierCount - 1
       return (0...maxTier).clamp(actualTier)
     } else {

--- a/ScienceJournal/ToneGenerator/ConductorSoundType.swift
+++ b/ScienceJournal/ToneGenerator/ConductorSoundType.swift
@@ -53,9 +53,13 @@ class ConductorSoundType: PitchedSoundType {
       return nil
     }
 
-    let index = Int(floor((value - valueThreshhold) / (currentMaximumValue - valueThreshhold) *
+    let index = Int(exactly: floor((value - valueThreshhold) / (currentMaximumValue - valueThreshhold) *
         Double(pitches.count - 1)))
-    return frequency(from: Double(pitches[index]))
+    if let index = index {
+      return frequency(from: Double(pitches[index]))
+    } else {
+      return nil
+    }
   }
 
 }

--- a/ScienceJournal/ToneGenerator/ScaleSoundType.swift
+++ b/ScienceJournal/ToneGenerator/ScaleSoundType.swift
@@ -28,8 +28,13 @@ class ScaleSoundType: PitchedSoundType {
                           valueMin: Double,
                           valueMax: Double,
                           timestamp: Int64) -> Double? {
-    let index = Int(floor((value - valueMin) / (valueMax - valueMin) * Double(pitches.count - 1)))
-    return frequency(from: Double(pitches[index]))
+    let floorValue = floor((value - valueMin) / (valueMax - valueMin) * Double(pitches.count - 1))
+    let index = Int(exactly: floorValue)
+    if let index = index {
+      return frequency(from: Double(pitches[index]))
+    } else {
+      return nil
+    }
   }
 
 }

--- a/ScienceJournal/ToneGenerator/ScaleSoundType.swift
+++ b/ScienceJournal/ToneGenerator/ScaleSoundType.swift
@@ -29,8 +29,7 @@ class ScaleSoundType: PitchedSoundType {
                           valueMax: Double,
                           timestamp: Int64) -> Double? {
     let floorValue = floor((value - valueMin) / (valueMax - valueMin) * Double(pitches.count - 1))
-    let index = Int(exactly: floorValue)
-    if let index = index {
+    if let index = Int(exactly: floorValue) {
       return frequency(from: Double(pitches[index]))
     } else {
       return nil

--- a/ScienceJournal/UI/RelativeScaleAnimationView.swift
+++ b/ScienceJournal/UI/RelativeScaleAnimationView.swift
@@ -27,9 +27,14 @@ class RelativeScaleAnimationView: ImageAnimationView {
 
     var valuePercentage = (value - minValue) / (maxValue - minValue)
     valuePercentage = max(min(valuePercentage, 1.0), 0)
-    let index = Int(floor(valuePercentage * Double(images.count)))
-    // If percentage is 1.0 index can be beyond count so clamp it.
-    return min(index, images.count - 1)
+    let index = Int(exactly: floor(valuePercentage * Double(images.count)))
+
+    if let index = index {
+      // If percentage is 1.0 index can be beyond count so clamp it.
+      return min(index, images.count - 1)
+    } else {
+      return 0
+    }
   }
 
 }

--- a/ScienceJournalTests/BLE/PacketAssemblerTest.swift
+++ b/ScienceJournalTests/BLE/PacketAssemblerTest.swift
@@ -264,7 +264,10 @@ class PacketAssemblerTest: XCTestCase {
     let bytes = [UInt8](protoData)
     let chunkSize = UInt8(isChunked ? bytes.count - 1 : bytes.count + 1)
 
-    let length = Int(ceil(Double(bytes.count) / Double(chunkSize)))
+    let potentialLength = Int(exactly: ceil(Double(bytes.count) / Double(chunkSize)))
+    guard let length = potentialLength else {
+      return
+    }
 
     var start = 0
     for index in 0..<length {


### PR DESCRIPTION
We have a couple crashes around anomalous data. We've been able to track it down to attempting to create an Int out of a Double that is too big to fit in an Int. 

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/google/science-journal-ios/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/google/science-journal-ios/blob/master/CHANGE_LIMITATIONS.md)

### Description
Updated most places where Ints can overflow by using `Int(exactly` which is a fail-able initializer.