### PR TITLE
[Lint] Closure clean up

### DIFF
--- a/ScienceJournal/Extensions/FileManager+ScienceJournal.swift
+++ b/ScienceJournal/Extensions/FileManager+ScienceJournal.swift
@@ -26,7 +26,7 @@ extension FileManager {
     var enumeratorError: Error?
     let enumerator = self.enumerator(at: url,
                                      includingPropertiesForKeys: URL.allocatedSizeResourceKeys,
-                                     options: []) { (url, error) -> Bool in
+                                     options: []) { (_, error) -> Bool in
       enumeratorError = error
       return false
     }

--- a/ScienceJournal/Notifications/LocalNotificationManager.swift
+++ b/ScienceJournal/Notifications/LocalNotificationManager.swift
@@ -51,7 +51,7 @@ class LocalNotificationManager: NSObject, UNUserNotificationCenterDelegate {
 
   /// Registers user notifications.
   func registerUserNotifications() {
-    userNotificationCenter.requestAuthorization(options: .alert) { (granted, error) in
+    userNotificationCenter.requestAuthorization(options: .alert) { (granted, _) in
       guard granted else {
         sjlog_error("Authorizationwas not granted for user notifications.", category: .general)
         DispatchQueue.main.async {

--- a/ScienceJournal/Operations/GSJOperationQueue.swift
+++ b/ScienceJournal/Operations/GSJOperationQueue.swift
@@ -79,7 +79,7 @@ open class GSJOperationQueue: OperationQueue {
       if !concurrencyCategories.isEmpty {
         let exclusivityController = ExclusivityController.shared
         exclusivityController.addOperation(gsjOp, categories: concurrencyCategories)
-        gsjOp.addObserver(BlockObserver { operation, errors in
+        gsjOp.addObserver(BlockObserver { operation, _ in
           exclusivityController.removeOperation(operation, categories: concurrencyCategories)
         })
       }

--- a/ScienceJournal/SensorData/UserAssetManager.swift
+++ b/ScienceJournal/SensorData/UserAssetManager.swift
@@ -59,7 +59,7 @@ open class UserAssetManager {
                                             sensorDataManager: sensorDataManager,
                                             trial: trial)
     writeTrialSensorDataToDiskOperation.addObserver(BlockObserver {
-        [unowned self] (operation, errors) in
+        [unowned self] (operation, _) in
       if operation.didFinishSuccessfully {
         self.driveSyncManager?.syncTrialSensorData(atURL: saveURL, experimentID: experiment.ID)
       }

--- a/ScienceJournal/Sensors/AltimeterSensor.swift
+++ b/ScienceJournal/Sensors/AltimeterSensor.swift
@@ -63,7 +63,7 @@ class AltimeterSensor: Sensor {
 
     state = .ready
     AltimeterSensor.altimeter.startRelativeAltitudeUpdates(to: .main) {
-        [weak self] (altitudeData, error) in
+        [weak self] (altitudeData, _) in
       if let altitudeData = altitudeData {
         self?.currentAltitudeData = altitudeData
       }

--- a/ScienceJournal/UI/AppFlowViewController.swift
+++ b/ScienceJournal/UI/AppFlowViewController.swift
@@ -475,7 +475,7 @@ extension AppFlowViewController: ExistingDataOptionsDelegate {
     let spinnerViewController = SpinnerViewController()
     spinnerViewController.present(fromViewController: existingDataOptionsVC) {
       self.existingDataMigrationManager?.migrateAllExperiments(completion: { (errors) in
-        spinnerViewController.dismissSpinner() {
+        spinnerViewController.dismissSpinner {
           self.showCurrentUserOrSignIn()
           if errors.containsDiskSpaceError {
             showSnackbar(withMessage: String.claimExperimentsDiskSpaceErrorMessage)
@@ -531,7 +531,7 @@ extension AppFlowViewController {
     guard let settingsVC = userFlowViewController?.settingsVC else { return }
     let spinnerVC = SpinnerViewController()
     spinnerVC.present(fromViewController: settingsVC) {
-      self.rootUserManager.documentManager.debug_createRootUserData() {
+      self.rootUserManager.documentManager.debug_createRootUserData {
         DispatchQueue.main.async {
           self.userFlowViewController?.experimentsListVC?.refreshUnclaimedExperiments()
           spinnerVC.dismissSpinner()

--- a/ScienceJournal/UI/ClaimExperimentsViewController.swift
+++ b/ScienceJournal/UI/ClaimExperimentsViewController.swift
@@ -189,7 +189,7 @@ class ClaimExperimentsViewController: MaterialHeaderViewController, ClaimExperim
           self.experimentsListItemsViewController.itemCount, email: self.authAccount.email)
       let alertController = MDCAlertController(title: nil, message: message)
       let claimAction =
-          MDCAlertAction(title: String.claimAllExperimentsConfirmationActionConfirm) { (action) in
+          MDCAlertAction(title: String.claimAllExperimentsConfirmationActionConfirm) { _ in
         self.delegate?.claimExperimentsClaimAllExperiments()
       }
       let cancelAction = MDCAlertAction(title: String.actionCancel)
@@ -208,7 +208,7 @@ class ClaimExperimentsViewController: MaterialHeaderViewController, ClaimExperim
           self.experimentsListItemsViewController.itemCount)
       let alertController = MDCAlertController(title: nil, message: message)
       let deleteAction =
-          MDCAlertAction(title: String.claimExperimentsDeleteAllConfirmationAction) { (action) in
+          MDCAlertAction(title: String.claimExperimentsDeleteAllConfirmationAction) { _ in
         self.delegate?.claimExperimentsDeleteAllExperiments()
       }
       let cancelAction = MDCAlertAction(title: String.actionCancel)
@@ -238,7 +238,7 @@ class ClaimExperimentsViewController: MaterialHeaderViewController, ClaimExperim
                                              message: message)
     let cancelAction = MDCAlertAction(title: String.actionCancel)
     let claimAction =
-        MDCAlertAction(title: String.claimExperimentConfirmationActionTitle) { (action) in
+        MDCAlertAction(title: String.claimExperimentConfirmationActionTitle) { _ in
       self.delegate?.claimExperimentsAddExperimentToDrive(withID: overview.experimentID)
     }
     alertController.addAction(claimAction)
@@ -260,7 +260,7 @@ class ClaimExperimentsViewController: MaterialHeaderViewController, ClaimExperim
     let alertController = MDCAlertController(title: String.deleteExperimentDialogTitle,
                                              message: String.deleteExperimentDialogMessage)
     let cancelAction = MDCAlertAction(title: String.btnDeleteObjectCancel)
-    let deleteAction = MDCAlertAction(title: String.btnDeleteObjectConfirm) { (action) in
+    let deleteAction = MDCAlertAction(title: String.btnDeleteObjectConfirm) { _ in
       self.delegate?.claimExperimentsDeleteExperiment(withID: overview.experimentID)
     }
     alertController.addAction(cancelAction)

--- a/ScienceJournal/UI/EditExperimentViewController.swift
+++ b/ScienceJournal/UI/EditExperimentViewController.swift
@@ -272,11 +272,11 @@ class EditExperimentViewController: MaterialHeaderViewController, EditExperiment
     let alertController =
         MDCAlertController(title: String.editExperimentUnsavedChangesDialogTitle,
                            message: String.editExperimentUnsavedChangesDialogMessage)
-    let saveAction = MDCAlertAction(title: String.btnEditExperimentSaveChanges) { (action) in
+    let saveAction = MDCAlertAction(title: String.btnEditExperimentSaveChanges) { _ in
       self.saveButtonPressed()
     }
     let deleteAction =
-        MDCAlertAction(title: String.btnEditExperimentDiscardChanges) { (action) in
+        MDCAlertAction(title: String.btnEditExperimentDiscardChanges) { _ in
       self.dismiss(animated: true)
     }
     alertController.addAction(saveAction)

--- a/ScienceJournal/UI/ExistingDataOptionsViewController.swift
+++ b/ScienceJournal/UI/ExistingDataOptionsViewController.swift
@@ -189,7 +189,7 @@ class ExistingDataOptionsViewController: ScienceJournalCollectionViewController 
           MDCAlertController(title: String.claimAllExperimentsMigrationConfirmationTitle,
                              message: message)
       let claimAction =
-          MDCAlertAction(title: String.claimAllExperimentsConfirmationAction) { (action) in
+          MDCAlertAction(title: String.claimAllExperimentsConfirmationAction) { _ in
         self.delegate?.existingDataOptionsViewControllerDidSelectSaveAllExperiments()
       }
       let cancelAction = MDCAlertAction(title: String.actionCancel)
@@ -204,7 +204,7 @@ class ExistingDataOptionsViewController: ScienceJournalCollectionViewController 
           MDCAlertController(title: String.claimExperimentsDeleteAllMigrationConfirmationTitle,
                              message: message)
       let deleteAction =
-          MDCAlertAction(title: String.claimExperimentsDeleteAllConfirmationAction) { (action) in
+          MDCAlertAction(title: String.claimExperimentsDeleteAllConfirmationAction) { _ in
         self.delegate?.existingDataOptionsViewControllerDidSelectDeleteAllExperiments()
       }
       let cancelAction = MDCAlertAction(title: String.actionCancel)

--- a/ScienceJournal/UI/ExperimentsListItemsViewController.swift
+++ b/ScienceJournal/UI/ExperimentsListItemsViewController.swift
@@ -158,7 +158,7 @@ class ExperimentsListItemsViewController: UIViewController, UICollectionViewData
   override func viewWillTransition(to size: CGSize,
                                    with coordinator: UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
-    coordinator.animate(alongsideTransition: { (context) in
+    coordinator.animate(alongsideTransition: { _ in
       self.collectionView.collectionViewLayout.invalidateLayout()
     })
   }

--- a/ScienceJournal/UI/ExperimentsListViewController.swift
+++ b/ScienceJournal/UI/ExperimentsListViewController.swift
@@ -700,7 +700,7 @@ class ExperimentsListViewController: MaterialHeaderViewController, ExperimentSta
       let alertController = MDCAlertController(title: String.deleteExperimentDialogTitle,
                                                message: String.deleteExperimentDialogMessage)
       let cancelAction = MDCAlertAction(title: String.btnDeleteObjectCancel)
-      let deleteAction = MDCAlertAction(title: String.btnDeleteObjectConfirm) { (action) in
+      let deleteAction = MDCAlertAction(title: String.btnDeleteObjectConfirm) { _ in
         // Delete the experiment and update the collection view.
         self.delegate?.experimentsListDeleteExperiment(withID: overview.experimentID)
       }

--- a/ScienceJournal/UI/MaterialHeaderCollectionViewController.swift
+++ b/ScienceJournal/UI/MaterialHeaderCollectionViewController.swift
@@ -99,7 +99,7 @@ class MaterialHeaderCollectionViewController: VisibilityTrackingCollectionViewCo
 
     // In iOS 9, a bug in MDCNavigationBar will cause right bar items to disappear on rotation
     // unless we layout the subviews once rotation animation is complete.
-    coordinator.animate(alongsideTransition: nil) { (context) in
+    coordinator.animate(alongsideTransition: nil) { _ in
       self.appBar.navigationBar.layoutSubviews()
     }
   }

--- a/ScienceJournal/UI/MaterialHeaderViewController.swift
+++ b/ScienceJournal/UI/MaterialHeaderViewController.swift
@@ -93,7 +93,7 @@ class MaterialHeaderViewController: ScienceJournalViewController, UIScrollViewDe
 
     // In iOS 9, a bug in MDCNavigationBar will cause right bar items to disappear on rotation
     // unless we layout the subviews once rotation animation is complete.
-    coordinator.animate(alongsideTransition: nil) { (context) in
+    coordinator.animate(alongsideTransition: nil) { _ in
       self.appBar.navigationBar.layoutSubviews()
     }
   }

--- a/ScienceJournal/UI/PictureDetailViewController.swift
+++ b/ScienceJournal/UI/PictureDetailViewController.swift
@@ -374,7 +374,7 @@ class PictureDetailViewController:
     // Info.
     let popUpMenu = PopUpMenuViewController()
     popUpMenu.addAction(PopUpMenuAction(title: String.pictureDetailInfo,
-                                        icon: UIImage(named: "ic_info")) { a -> Void in
+                                        icon: UIImage(named: "ic_info")) { _ in
       self.navigationController?.pushViewController(
           PictureInfoViewController(displayPicture: self.displayPicture,
                                     analyticsReporter: self.analyticsReporter,
@@ -400,7 +400,7 @@ class PictureDetailViewController:
     // Delete.
     func addDeleteAction() {
       popUpMenu.addAction(PopUpMenuAction(title: String.deleteNoteMenuItem,
-                                          icon: UIImage(named: "ic_delete")) { a -> Void in
+                                          icon: UIImage(named: "ic_delete")) { _ in
         self.delegate?.detailViewControllerDidDeleteNote(self.displayPicture)
         self.navigationController?.popViewController(animated: true)
       })

--- a/ScienceJournal/UI/SidebarViewController.swift
+++ b/ScienceJournal/UI/SidebarViewController.swift
@@ -232,7 +232,7 @@ class SidebarViewController: UIViewController, UICollectionViewDelegate, UIColle
   override func viewWillTransition(to size: CGSize,
                                    with coordinator: UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
-    coordinator.animate(alongsideTransition: nil) { (context) in
+    coordinator.animate(alongsideTransition: nil) { _ in
       self.wrapperViewTopConstraint?.constant = -self.statusBarHeight
       self.wrapperView.layoutIfNeeded()
     }
@@ -305,7 +305,7 @@ class SidebarViewController: UIViewController, UICollectionViewDelegate, UIColle
 
   func sidebarAccountViewTapped() {
     // Hide the sidebar and when that's done, tell the delegate to show the account selector.
-    hide() {
+    hide {
       self.delegate?.sidebarShouldShowSignIn()
     }
     analyticsReporter.track(.signInFromSidebar)
@@ -409,7 +409,7 @@ class SidebarViewController: UIViewController, UICollectionViewDelegate, UIColle
 
   func collectionView(_ collectionView: UICollectionView,
                       didSelectItemAt indexPath: IndexPath) {
-    hide() {
+    hide {
       self.delegate?.sidebarShouldShow(self.menuStructure[indexPath.item])
     }
   }

--- a/ScienceJournal/UI/SignInViewController.swift
+++ b/ScienceJournal/UI/SignInViewController.swift
@@ -80,7 +80,7 @@ class SignInViewController: OnboardingViewController {
                                    with coordinator: UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
 
-    coordinator.animate(alongsideTransition: { (context) in
+    coordinator.animate(alongsideTransition: { _ in
       self.updateViewForSize(size)
       self.view.layoutIfNeeded()
     })

--- a/ScienceJournal/UI/UserFlowViewController.swift
+++ b/ScienceJournal/UI/UserFlowViewController.swift
@@ -858,7 +858,7 @@ class UserFlowViewController: UIViewController, ExperimentsListViewControllerDel
       var spinnerVC: SpinnerViewController?
 
       let createDefaultExperiment = {
-        driveSyncManager.experimentLibraryExists() { (libraryExists) in
+        driveSyncManager.experimentLibraryExists { (libraryExists) in
           // If existence is unknown, perhaps due to a fetch error or lack of network, don't create
           // the default experiment.
           if libraryExists == false {
@@ -868,7 +868,7 @@ class UserFlowViewController: UIViewController, ExperimentsListViewControllerDel
 
             DispatchQueue.main.async {
               if let spinnerVC = spinnerVC {
-                spinnerVC.dismissSpinner() {
+                spinnerVC.dismissSpinner {
                   self.experimentsListVC?.reloadExperiments()
                   finished()
                 }
@@ -882,7 +882,7 @@ class UserFlowViewController: UIViewController, ExperimentsListViewControllerDel
             self.preferenceManager.defaultExperimentWasCreated = true
             DispatchQueue.main.async {
               if let spinnerVC = spinnerVC {
-               spinnerVC.dismissSpinner() {
+               spinnerVC.dismissSpinner {
                  finished()
                 }
               } else {

--- a/ScienceJournal/UI/WelcomeViewController.swift
+++ b/ScienceJournal/UI/WelcomeViewController.swift
@@ -64,7 +64,7 @@ class WelcomeViewController: OnboardingViewController {
                                    with coordinator: UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
 
-    coordinator.animate(alongsideTransition: { (context) in
+    coordinator.animate(alongsideTransition: { _ in
       self.updateConstraintsForSize(size)
       self.view.layoutIfNeeded()
     })

--- a/ScienceJournal/WrappedModels/TriggerInformation.swift
+++ b/ScienceJournal/WrappedModels/TriggerInformation.swift
@@ -55,7 +55,7 @@ class TriggerInformation {
   var triggerAlertTypes: [GSJTriggerInformation_TriggerAlertType] {
     get {
       var types = [GSJTriggerInformation_TriggerAlertType]()
-      proto.triggerAlertTypesArray.enumerateValues({ (value, index, stop) in
+      proto.triggerAlertTypesArray.enumerateValues({ (value, _, _) in
         types.append(GSJTriggerInformation_TriggerAlertType(rawValue: value)!)
       })
       return types


### PR DESCRIPTION
unused closure parameters get underscores
function calls with trailing closures shouldn't have parens before closure

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/google/science-journal-ios/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/google/science-journal-ios/blob/master/CHANGE_LIMITATIONS.md)
