### PR TITLE
[Lint] Delegate should be weak

### DIFF
--- a/ScienceJournal/UI/TriggerTypeSelectorView.swift
+++ b/ScienceJournal/UI/TriggerTypeSelectorView.swift
@@ -19,7 +19,7 @@ import UIKit
 import third_party_objective_c_material_components_ios_components_Typography_Typography
 import third_party_sciencejournal_ios_ScienceJournalProtos
 
-protocol TriggerTypeSelectorDelegate {
+protocol TriggerTypeSelectorDelegate: class {
   /// Calls the delegate when the type changes.
   func triggerTypeSelectorView(_ triggerTypeSelectorView: TriggerTypeSelectorView,
                                didSelectType triggerType: GSJTriggerInformation_TriggerActionType)
@@ -29,7 +29,7 @@ protocol TriggerTypeSelectorDelegate {
 class TriggerTypeSelectorView: TriggerOptionSelectorView {
 
   // The delegate.
-  var triggerTypeSelectorDelegate: TriggerTypeSelectorDelegate?
+  weak var triggerTypeSelectorDelegate: TriggerTypeSelectorDelegate?
 
   // MARK: Properties
 

--- a/ScienceJournalTests/Metadata/ExperimentDataDeleterTest.swift
+++ b/ScienceJournalTests/Metadata/ExperimentDataDeleterTest.swift
@@ -54,7 +54,7 @@ class ExperimentDataDeleterTest: XCTestCase {
     XCTAssertNotNil(deletedExperiment)
     assertExperimentIsDeleted(withID: experimentID)
 
-    experimentDataDeleter.restoreExperiment(deletedExperiment!)
+    _ = experimentDataDeleter.restoreExperiment(deletedExperiment!)
     assertExperimentExists(withID: experimentID)
     assertSensorDataExists(forTrialID: experiment.trials[0].ID)
   }


### PR DESCRIPTION
delegate protocol also needs to be class-bound in order to be weak
Fix warning on unused return result in test

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/google/science-journal-ios/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/google/science-journal-ios/blob/master/CHANGE_LIMITATIONS.md)
