### PR TITLE
Resolves extra padding on recording cell top edge

### DIFF
--- a/ScienceJournal/UI/ExperimentItemsViewController.swift
+++ b/ScienceJournal/UI/ExperimentItemsViewController.swift
@@ -431,15 +431,31 @@ class ExperimentItemsViewController: VisibilityTrackingViewController,
 
   // MARK: - UICollectionViewDelegate
 
-  // TODO: Investigate why this can't just be set on the flowLayout as `sectionInset`.
-  // For some reason, it's not adding appropriate section insets to the top and bottom.
   func collectionView(_ collectionView: UICollectionView,
                       layout collectionViewLayout: UICollectionViewLayout,
                       insetForSectionAt section: Int) -> UIEdgeInsets {
-    if experimentDataSource.numberOfItemsInSection(section) == 0 {
-      return .zero
+    // Determine the last section with items.
+    var lastSectionWithItems: Int?
+    for i in 0..<experimentDataSource.numberOfSections {
+      if experimentDataSource.numberOfItemsInSection(i) > 0 {
+        lastSectionWithItems = i
+      }
     }
-    return cellInsets
+
+    if experimentDataSource.numberOfItemsInSection(section) == 0 {
+      // If the section is empty, no insets.
+      return .zero
+    } else if section == lastSectionWithItems {
+      // If this is the last section with items, include the bottom inset.
+      return cellInsets
+    } else {
+      // If this is not the last section with items section, but this section has items,
+      // use standard insets without bottom. This avoids an issue where two stacked
+      // sections double padding.
+      var modifiedInsets = cellInsets
+      modifiedInsets.bottom = 0
+      return modifiedInsets
+    }
   }
 
   func collectionView(_ collectionView: UICollectionView,

--- a/ScienceJournal/UI/ExperimentItemsViewController.swift
+++ b/ScienceJournal/UI/ExperimentItemsViewController.swift
@@ -436,9 +436,7 @@ class ExperimentItemsViewController: VisibilityTrackingViewController,
   func collectionView(_ collectionView: UICollectionView,
                       layout collectionViewLayout: UICollectionViewLayout,
                       insetForSectionAt section: Int) -> UIEdgeInsets {
-    if experimentDataSource.isArchivedFlagSection(section) &&
-        experimentDataSource.numberOfItemsInSection(
-        experimentDataSource.archivedFlagSectionIndex) == 0 {
+    if experimentDataSource.numberOfItemsInSection(section) == 0 {
       return .zero
     }
     return cellInsets


### PR DESCRIPTION
<!-- Thanks for contributing to Science Journal iOS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/google/science-journal-ios/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/google/science-journal-ios/blob/master/CHANGE_LIMITATIONS.md)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/google/science-journal-ios/issues/46

### Description
<!-- Describe your changes in detail -->
Provide zero section insets when there are no cells in the corresponding section.
<!-- Please describe in detail how you tested your changes. -->
Manual testing of various UI states in multiple orientations, on iPhone and iPad simulators.