### PR TITLE
Ensure crop points are current

### DIFF
--- a/ScienceJournal/UI/CropRangeViewController.swift
+++ b/ScienceJournal/UI/CropRangeViewController.swift
@@ -61,10 +61,10 @@ class CropRangeViewController: UIViewController, EditTimestampViewControllerDele
   /// Shows an alert that allows the user to manually input a timestamp for the given crop marker.
   ///
   /// - Parameters
-  ///   - trialCropRange: The trial's crop range.
   ///   - markerType: A crop marker type.
-  func showTimestampEditAlert(forTrialCropRange trialCropRange: ChartAxis<Int64>,
-                              andCropMarkerType markerType: CropOverlayView.MarkerType) {
+  ///   - trialCropRange: The trial's crop range.
+  func showTimestampEditAlert(for markerType: CropOverlayView.MarkerType,
+                              trialCropRange: ChartAxis<Int64>) {
     self.trialCropRange = trialCropRange
 
     let editTimestampVC = EditTimestampViewController()

--- a/ScienceJournal/UI/CropRangeViewController.swift
+++ b/ScienceJournal/UI/CropRangeViewController.swift
@@ -37,7 +37,7 @@ class CropRangeViewController: UIViewController, EditTimestampViewControllerDele
   weak var delegate: CropRangeViewControllerDelegate?
 
   /// The crop range of the trial.
-  var trialCropRange: ChartAxis<Int64>?
+  private var trialCropRange: ChartAxis<Int64>?
 
   private var alertPresentation: TimestampAlertPresentation?
   private let trialRecordingRange: ChartAxis<Int64>
@@ -47,10 +47,8 @@ class CropRangeViewController: UIViewController, EditTimestampViewControllerDele
   /// Designated initializer
   ///
   /// - Parameters:
-  ///   - trialCropRange: The trial's crop range.
   ///   - trialRecordingRange: The trial's recording range.
-  init(trialCropRange: ChartAxis<Int64>?, trialRecordingRange: ChartAxis<Int64>) {
-    self.trialCropRange = trialCropRange
+  init(trialRecordingRange: ChartAxis<Int64>) {
     self.trialRecordingRange = trialRecordingRange
     cropValidator = CropValidator(trialRecordingRange: trialRecordingRange)
     super.init(nibName: nil, bundle: nil)
@@ -62,11 +60,12 @@ class CropRangeViewController: UIViewController, EditTimestampViewControllerDele
 
   /// Shows an alert that allows the user to manually input a timestamp for the given crop marker.
   ///
-  /// - Parameter marker: A crop marker type.
-  func showTimestampEditAlert(forCropMarkerType markerType: CropOverlayView.MarkerType) {
-    guard let trialCropRange = trialCropRange else {
-      return
-    }
+  /// - Parameters
+  ///   - trialCropRange: The trial's crop range.
+  ///   - markerType: A crop marker type.
+  func showTimestampEditAlert(forTrialCropRange trialCropRange: ChartAxis<Int64>,
+                              andCropMarkerType markerType: CropOverlayView.MarkerType) {
+    self.trialCropRange = trialCropRange
 
     let editTimestampVC = EditTimestampViewController()
     editTimestampVC.delegate = self

--- a/ScienceJournal/UI/TrialDetailViewController.swift
+++ b/ScienceJournal/UI/TrialDetailViewController.swift
@@ -260,8 +260,7 @@ class TrialDetailViewController: MaterialHeaderViewController,
     self.preferenceManager = preferenceManager
     self.sensorDataManager = sensorDataManager
     cropValidator = CropValidator(trialRecordingRange: trial.recordingRange)
-    cropRangeController = CropRangeViewController(trialCropRange: trial.cropRange,
-                                                  trialRecordingRange: trial.recordingRange)
+    cropRangeController = CropRangeViewController(trialRecordingRange: trial.recordingRange)
 
     // MDCCollectionViewFlowLayout currently has a bug that breaks sectionHeadersPinToVisibleBounds
     // so we need to use a UICollectionViewFlowLayout instead until it's fixed. See issue:
@@ -1128,8 +1127,6 @@ class TrialDetailViewController: MaterialHeaderViewController,
                                         recordingRange: trial.recordingRange)
       }
     }
-
-    cropRangeController.trialCropRange = editingCropRange
   }
 
   private func endCropping() {
@@ -1296,15 +1293,23 @@ class TrialDetailViewController: MaterialHeaderViewController,
 
     // Edit start time.
     actions.append(PopUpMenuAction(title: String.editCropStartTime, isEnabled: true) { _ in
-      self.cropRangeController.showTimestampEditAlert(forCropMarkerType: .start)
+      self.showTimestampEditAlert(for: .start)
     })
 
     // Edit end time.
     actions.append(PopUpMenuAction(title: String.editCropEndTime, isEnabled: true) { _ in
-      self.cropRangeController.showTimestampEditAlert(forCropMarkerType: .end)
+      self.showTimestampEditAlert(for: .end)
     })
 
     return actions
+  }
+
+  private func showTimestampEditAlert(for cropMarkerType: CropOverlayView.MarkerType) {
+    guard let trialCropRange = self.currentPlaybackViewController?.1.cropRange else {
+      return
+    }
+    self.cropRangeController.showTimestampEditAlert(forTrialCropRange: trialCropRange,
+                                                    andCropMarkerType: cropMarkerType)
   }
 
   /// Creates trial data for export.

--- a/ScienceJournal/UI/TrialDetailViewController.swift
+++ b/ScienceJournal/UI/TrialDetailViewController.swift
@@ -1308,8 +1308,8 @@ class TrialDetailViewController: MaterialHeaderViewController,
     guard let trialCropRange = self.currentPlaybackViewController?.1.cropRange else {
       return
     }
-    self.cropRangeController.showTimestampEditAlert(forTrialCropRange: trialCropRange,
-                                                    andCropMarkerType: cropMarkerType)
+    self.cropRangeController.showTimestampEditAlert(for: cropMarkerType,
+                                                    trialCropRange: trialCropRange)
   }
 
   /// Creates trial data for export.


### PR DESCRIPTION
<!-- Thanks for contributing to Science Journal iOS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/google/science-journal-ios/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/google/science-journal-ios/blob/master/CHANGE_LIMITATIONS.md)

### Motivation and Context

Previously setting the crop points via the text entry dialog would update the sliders, but moving the sliders would not update the pre-populated values in the text entry dialog. This was due to the text
field being populated with the `Trial` values, which aren't updated until the crop changes are saved.

Fixes #47 

### Description

This change uses the crop values from the current playback view controller, which is the same value that the sliders present and modify.

There do not appear to be tests for this part of the app, so I did not add or update any. I tested the change manually by modifying the crop points through both the sliders and the text input dialog and ensuring that the changes were reflected in the corresponding UI.