### PR TITLE
Bluetooth unavailable message

### DIFF
--- a/ScienceJournal/Resources/Strings.bundle/en.lproj/Localizable.strings
+++ b/ScienceJournal/Resources/Strings.bundle/en.lproj/Localizable.strings
@@ -1195,6 +1195,9 @@
 /* Long description of an unknown bluetooth sensor displayed below a representative image on the Learn More page [CHAR_LIMIT=NONE] */
 "sensor_desc_second_paragraph_unknown_bluetooth" = "Bluetooth is a wireless technology standard using radio waves to exchange data over short distances from fixed and mobile devices.";
 
+/* Message to display to the user when bluetooth is not on but a bluetooth sensor is in the experiment on Observe [CHAR_LIMIT=200] */
+"bluetooth_not_on_body" = "Cannot connect to external sensor: Bluetooth is disabled. Turn on Bluetooth to connect to your external sensor.";
+
 /* One-sentence description of the accelerometer X sensor [CHAR_LIMIT=100] */
 "sensor_desc_short_acc_x" = "The acceleration of the phone to the left and right, in m/s²";
 
@@ -1554,3 +1557,5 @@
 
 /* Displayed units for a Voltage sensor [CHAR_LIMIT=10] */
 "voltage_units" = "V";
+
+"radibarq" = "hello world";

--- a/ScienceJournal/Resources/Strings.bundle/en.lproj/Localizable.strings
+++ b/ScienceJournal/Resources/Strings.bundle/en.lproj/Localizable.strings
@@ -1195,9 +1195,9 @@
 /* Long description of an unknown bluetooth sensor displayed below a representative image on the Learn More page [CHAR_LIMIT=NONE] */
 "sensor_desc_second_paragraph_unknown_bluetooth" = "Bluetooth is a wireless technology standard using radio waves to exchange data over short distances from fixed and mobile devices.";
 
-/* Message to display to the user when bluetooth is not on but a bluetooth sensor is in the experiment on Observe [CHAR_LIMIT=200] */
-"bluetooth_not_on_body" = "Cannot connect to external sensor: Bluetooth is disabled. Turn on Bluetooth to connect to your external sensor.";
-
+/* Message to display to the user when Bluetooth is disabled but a Bluetooth sensor is listed in sensor settings because it has been connected in the past [CHAR_LIMIT=200] */
+"bluetooth_hardware_disabled_message" = "Cannot connect to external sensor: Bluetooth is disabled. Turn on Bluetooth to connect to your external sensor.";
+ 
 /* One-sentence description of the accelerometer X sensor [CHAR_LIMIT=100] */
 "sensor_desc_short_acc_x" = "The acceleration of the phone to the left and right, in m/s²";
 

--- a/ScienceJournal/Resources/Strings.bundle/en.lproj/Localizable.strings
+++ b/ScienceJournal/Resources/Strings.bundle/en.lproj/Localizable.strings
@@ -1557,5 +1557,3 @@
 
 /* Displayed units for a Voltage sensor [CHAR_LIMIT=10] */
 "voltage_units" = "V";
-
-"radibarq" = "hello world";

--- a/ScienceJournal/Strings/ScienceJournalStrings.swift
+++ b/ScienceJournal/Strings/ScienceJournalStrings.swift
@@ -544,7 +544,6 @@ extension String {
   static public var userFeedbackEmailInfoSendButton: String { return "user_feedback_email_info_send_button".localized }
   static public var videoStream: String { return "video_stream".localized }
   static public var voltageUnits: String { return "voltage_units".localized }
-  static public var radibarq: String { return "radibarq".localized }
 
 }
 

--- a/ScienceJournal/Strings/ScienceJournalStrings.swift
+++ b/ScienceJournal/Strings/ScienceJournalStrings.swift
@@ -423,6 +423,7 @@ extension String {
   static public var sensorDescSecondParagraphRotation: String { return "sensor_desc_second_paragraph_rotation".localized }
   static public var sensorDescFirstParagraphUnknownBluetooth: String { return "sensor_desc_first_paragraph_unknown_bluetooth".localized }
   static public var sensorDescSecondParagraphUnknownBluetooth: String { return "sensor_desc_second_paragraph_unknown_bluetooth".localized }
+  static public var bluetoothNotOnBody: String { return "bluetooth_not_on_body".localized }
   static public var sensorDescShortAccX: String { return "sensor_desc_short_acc_x".localized }
   static public var sensorDescShortAccY: String { return "sensor_desc_short_acc_y".localized }
   static public var sensorDescShortAccZ: String { return "sensor_desc_short_acc_z".localized }
@@ -543,6 +544,7 @@ extension String {
   static public var userFeedbackEmailInfoSendButton: String { return "user_feedback_email_info_send_button".localized }
   static public var videoStream: String { return "video_stream".localized }
   static public var voltageUnits: String { return "voltage_units".localized }
+  static public var radibarq: String { return "radibarq".localized }
 
 }
 

--- a/ScienceJournal/Strings/ScienceJournalStrings.swift
+++ b/ScienceJournal/Strings/ScienceJournalStrings.swift
@@ -423,7 +423,7 @@ extension String {
   static public var sensorDescSecondParagraphRotation: String { return "sensor_desc_second_paragraph_rotation".localized }
   static public var sensorDescFirstParagraphUnknownBluetooth: String { return "sensor_desc_first_paragraph_unknown_bluetooth".localized }
   static public var sensorDescSecondParagraphUnknownBluetooth: String { return "sensor_desc_second_paragraph_unknown_bluetooth".localized }
-  static public var bluetoothNotOnBody: String { return "bluetooth_not_on_body".localized }
+  static public var bluetoothHardwareDisabledMessage: String { return "bluetooth_hardware_disabled_message".localized }
   static public var sensorDescShortAccX: String { return "sensor_desc_short_acc_x".localized }
   static public var sensorDescShortAccY: String { return "sensor_desc_short_acc_y".localized }
   static public var sensorDescShortAccZ: String { return "sensor_desc_short_acc_z".localized }

--- a/ScienceJournal/UI/SensorSettingsDataSource.swift
+++ b/ScienceJournal/UI/SensorSettingsDataSource.swift
@@ -444,7 +444,7 @@ class SensorSettingsDataSource: BLEServiceScannerDelegate {
   }
 
   func serviceScannerBluetoothAvailabilityChanged(_ serviceScanner: BLEServiceScanner) {
-    // TODO: Display message if Bluetooth is unavailable.
+     delegate?.sensorSettingsDataSourceNeedsRefresh(self)
   }
 
 }

--- a/ScienceJournal/UI/SensorSettingsDataSource.swift
+++ b/ScienceJournal/UI/SensorSettingsDataSource.swift
@@ -444,7 +444,7 @@ class SensorSettingsDataSource: BLEServiceScannerDelegate {
   }
 
   func serviceScannerBluetoothAvailabilityChanged(_ serviceScanner: BLEServiceScanner) {
-     delegate?.sensorSettingsDataSourceNeedsRefresh(self)
+    delegate?.sensorSettingsDataSourceNeedsRefresh(self)
   }
 
 }

--- a/ScienceJournal/UI/SensorSettingsDataSource.swift
+++ b/ScienceJournal/UI/SensorSettingsDataSource.swift
@@ -444,7 +444,7 @@ class SensorSettingsDataSource: BLEServiceScannerDelegate {
   }
 
   func serviceScannerBluetoothAvailabilityChanged(_ serviceScanner: BLEServiceScanner) {
-    delegate?.sensorSettingsDataSourceNeedsRefresh(self)
+    showSnackbar(withMessage: String.bluetoothHardwareDisabledMessage)
   }
-
+    
 }

--- a/ScienceJournal/UI/SensorSettingsViewController.swift
+++ b/ScienceJournal/UI/SensorSettingsViewController.swift
@@ -227,6 +227,9 @@ class SensorSettingsViewController: MaterialHeaderCollectionViewController,
   // MARK: - SensorSettingsDataSourceDelegate
 
   func sensorSettingsDataSourceNeedsRefresh(_ dataSource: SensorSettingsDataSource) {
+    if !dataSource.serviceScanner.isBluetoothAvailable {
+        showSnackbar(withMessage: String.bluetoothNotOnBody)
+    }
     collectionView?.reloadData()
   }
 

--- a/ScienceJournal/UI/SensorSettingsViewController.swift
+++ b/ScienceJournal/UI/SensorSettingsViewController.swift
@@ -228,7 +228,7 @@ class SensorSettingsViewController: MaterialHeaderCollectionViewController,
 
   func sensorSettingsDataSourceNeedsRefresh(_ dataSource: SensorSettingsDataSource) {
     if !dataSource.serviceScanner.isBluetoothAvailable {
-        showSnackbar(withMessage: String.bluetoothNotOnBody)
+      showSnackbar(withMessage: String.bluetoothNotOnBody)
     }
     collectionView?.reloadData()
   }

--- a/ScienceJournal/UI/SensorSettingsViewController.swift
+++ b/ScienceJournal/UI/SensorSettingsViewController.swift
@@ -227,9 +227,6 @@ class SensorSettingsViewController: MaterialHeaderCollectionViewController,
   // MARK: - SensorSettingsDataSourceDelegate
 
   func sensorSettingsDataSourceNeedsRefresh(_ dataSource: SensorSettingsDataSource) {
-    if !dataSource.serviceScanner.isBluetoothAvailable {
-      showSnackbar(withMessage: String.bluetoothNotOnBody)
-    }
     collectionView?.reloadData()
   }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Science Journal iOS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/google/science-journal-ios/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/google/science-journal-ios/blob/master/CHANGE_LIMITATIONS.md)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
been raised an issue on github. 

<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/google/science-journal-ios/issues/25

### Description
<!-- Describe your changes in detail -->
now a snackbar appears on sensor settings view when the bluetooth is not available.

<!-- Please describe in detail how you tested your changes. -->
I ran the feature on my device, made sure it works fine.
I ran related tests on Xcode.
