### PR TITLE
Fix Memory leak

### DIFF
--- a/ScienceJournal/CaptureSession/AudioCapture.swift
+++ b/ScienceJournal/CaptureSession/AudioCapture.swift
@@ -154,6 +154,9 @@ class AudioCapture: NSObject, AVCaptureAudioDataOutputSampleBufferDelegate {
                      from connection: AVCaptureConnection) {
     var blockBuffer: CMBlockBuffer?
     let audioBufferList = AudioBufferList.allocate(maximumBuffers: 1)
+    defer {
+      free(audioBufferList.unsafeMutablePointer)
+    }
     CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
       sampleBuffer,
       bufferListSizeNeededOut: nil,


### PR DESCRIPTION
<!-- Thanks for contributing to Science Journal iOS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/google/science-journal-ios/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/google/science-journal-ios/blob/master/CHANGE_LIMITATIONS.md)

### Motivation and Context

The memory leaks occur continuously while selecting the "Pinch" tab.
<img src="https://user-images.githubusercontent.com/45647069/64110114-26cc9c00-cdbc-11e9-98a0-dc05e07f959b.PNG" height=400>
<br />
I watched it by *Instruments*.
<img width="1396" src="https://user-images.githubusercontent.com/45647069/64112882-a6aa3480-cdc3-11e9-98ad-f2cc284e010d.png">



### Description

Insert `free()`.  

Reference
  - https://github.com/apple/swift/blob/6e7051eb1e38e743a514555d09256d12d3fec750/stdlib/public/Darwin/CoreAudio/CoreAudio.swift#L67

