### PR TITLE
Fix action area multiline button alignment

### DIFF
--- a/ScienceJournal/ActionArea/ActionAreaBarViewController.swift
+++ b/ScienceJournal/ActionArea/ActionAreaBarViewController.swift
@@ -406,7 +406,7 @@ extension ActionArea {
     private let stackView: UIStackView = {
       let view = UIStackView()
       view.axis = .horizontal
-      view.alignment = .center
+      view.alignment = .firstBaseline
       view.distribution = .fillEqually
       // The stack view needs at least one view to calculate its intrinsic content size.
       view.addArrangedSubview(UIView())
@@ -472,6 +472,7 @@ extension ActionArea {
     private let label: UILabel = {
       let view = UILabel()
       view.numberOfLines = 2
+      view.textAlignment = .center
       view.textColor = BarViewController.Metrics.Bar.buttonTitleColor
       return view
     }()


### PR DESCRIPTION
<!-- Thanks for contributing to Science Journal iOS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/google/science-journal-ios/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/google/science-journal-ios/blob/master/CHANGE_LIMITATIONS.md)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When using a `ActionArea.BarButtonItem` with more than one line of text, the buttons will align improperly:

<img width="719" alt="Screen Shot 2019-10-08 at 12 24 46 PM" src="https://user-images.githubusercontent.com/1952578/66426662-2d57c000-e9c7-11e9-9b40-be3db8fd8dcd.png">


### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

This changes the stackview's alignment to `. firstBaseline` and horizontally centers the text:

Two lines:
<img width="715" alt="Screen Shot 2019-10-08 at 12 21 56 PM" src="https://user-images.githubusercontent.com/1952578/66426706-46f90780-e9c7-11e9-910b-0cbade2f8af6.png">

One line:
<img width="716" alt="image" src="https://user-images.githubusercontent.com/1952578/66426777-714ac500-e9c7-11e9-9f77-eaa0e86d82b4.png">
