### PR TITLE
add ScrollViewContentObserver

### DIFF
--- a/ScienceJournal.xcodeproj/project.pbxproj
+++ b/ScienceJournal.xcodeproj/project.pbxproj
@@ -416,6 +416,7 @@
 		68EBA6E51E20421E0089FF7F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 68EBA6E41E20421E0089FF7F /* Assets.xcassets */; };
 		68F14AC21F21801F0054E799 /* TimeInterval+ScienceJournal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68F14AC11F21801F0054E799 /* TimeInterval+ScienceJournal.swift */; };
 		68FB61111F3A70DA008281DB /* MaterialFloatingSpinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FB61101F3A70DA008281DB /* MaterialFloatingSpinner.swift */; };
+		86EBD8E3234E81B1004DFCB9 /* ScrollViewContentObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8692DC31234E544800052CE3 /* ScrollViewContentObserver.swift */; };
 		8B00318021346C1500B9BBFB /* PullToRefreshController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B00317E21346C1500B9BBFB /* PullToRefreshController.swift */; };
 		8B031EEC2098BA6D008F6F28 /* ExistingDataOptionsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B031EEB2098BA6D008F6F28 /* ExistingDataOptionsHeaderView.swift */; };
 		8B031EEE2098C39C008F6F28 /* ExistingDataOptionsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B031EED2098C39C008F6F28 /* ExistingDataOptionsCell.swift */; };
@@ -1108,6 +1109,7 @@
 		68FB61101F3A70DA008281DB /* MaterialFloatingSpinner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MaterialFloatingSpinner.swift; sourceTree = "<group>"; };
 		716FC707D21F24E45C613BEC /* Pods-ScienceJournalUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScienceJournalUITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ScienceJournalUITests/Pods-ScienceJournalUITests.release.xcconfig"; sourceTree = "<group>"; };
 		81B6ADB3C8B55839B4C266D2 /* Pods-ScienceJournal.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScienceJournal.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ScienceJournal/Pods-ScienceJournal.debug.xcconfig"; sourceTree = "<group>"; };
+		8692DC31234E544800052CE3 /* ScrollViewContentObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ScrollViewContentObserver.swift; path = ../UI/ScrollViewContentObserver.swift; sourceTree = "<group>"; };
 		8B00317E21346C1500B9BBFB /* PullToRefreshController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PullToRefreshController.swift; sourceTree = "<group>"; };
 		8B031EEB2098BA6D008F6F28 /* ExistingDataOptionsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistingDataOptionsHeaderView.swift; sourceTree = "<group>"; };
 		8B031EED2098C39C008F6F28 /* ExistingDataOptionsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistingDataOptionsCell.swift; sourceTree = "<group>"; };
@@ -2561,6 +2563,7 @@
 				58BC1BC422C18FEB00DA7EDC /* UIImage+ScienceJournal.swift */,
 				8BA5BF331F44904F00EB77E8 /* UIPanGestureRecognizer+ScienceJournal.swift */,
 				48E48DC022A63CEB004301E4 /* UIScrollView+Capturing.swift */,
+				8692DC31234E544800052CE3 /* ScrollViewContentObserver.swift */,
 				8B9C59471F478A820063FFA9 /* UIScrollView+ScienceJournal.swift */,
 				684896E81F0207CD00DF1EE2 /* UIStackView+ScienceJournal.swift */,
 				5C8784A421679E040046786D /* UITextView+ScienceJournal.swift */,
@@ -3730,6 +3733,7 @@
 				8B882A5320ADDEA000E93179 /* AddExperimentsToDriveView.swift in Sources */,
 				68BD95671E8DA45100FEB0B2 /* ToneGenerator.swift in Sources */,
 				680D406E1F03083C004E5555 /* SnapshotDetailViewController.swift in Sources */,
+				86EBD8E3234E81B1004DFCB9 /* ScrollViewContentObserver.swift in Sources */,
 				5C878523216E602C0046786D /* GradientView.swift in Sources */,
 				5C6C62651EE0819A00798989 /* SnapshotNote.swift in Sources */,
 				5C72196F1EDFA2E900817F0B /* PictureNote.swift in Sources */,

--- a/ScienceJournal/UI/MaterialHeaderViewController.swift
+++ b/ScienceJournal/UI/MaterialHeaderViewController.swift
@@ -28,7 +28,8 @@ class MaterialHeaderViewController: ScienceJournalViewController, UIScrollViewDe
 
   let appBar = MDCAppBar()
   var trackedScrollView: UIScrollView? { return nil }
-  @objc dynamic private(set) var isContentOutsideOfSafeArea: Bool = false
+  @objc private(set) lazy var scrollViewContentObserver
+    = ScrollViewContentObserver(scrollView: trackedScrollView)
   private weak var existingInteractivePopGestureRecognizerDelegate : UIGestureRecognizerDelegate?
 
   // MARK: - MaterialHeader
@@ -120,10 +121,6 @@ class MaterialHeaderViewController: ScienceJournalViewController, UIScrollViewDe
   // MARK: - UIScrollViewDelegate
 
   func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    if isContentOutsideOfSafeArea != scrollView.isContentOutsideOfSafeArea {
-      isContentOutsideOfSafeArea = scrollView.isContentOutsideOfSafeArea
-    }
-
     if scrollView == appBar.headerViewController.headerView.trackingScrollView {
       appBar.headerViewController.headerView.trackingScrollDidScroll()
     }

--- a/ScienceJournal/UI/MaterialHeaderViewController.swift
+++ b/ScienceJournal/UI/MaterialHeaderViewController.swift
@@ -28,8 +28,8 @@ class MaterialHeaderViewController: ScienceJournalViewController, UIScrollViewDe
 
   let appBar = MDCAppBar()
   var trackedScrollView: UIScrollView? { return nil }
-  @objc private(set) lazy var scrollViewContentObserver
-    = ScrollViewContentObserver(scrollView: trackedScrollView)
+  @objc private(set) lazy var scrollViewContentObserver =
+    ScrollViewContentObserver(scrollView: trackedScrollView)
   private weak var existingInteractivePopGestureRecognizerDelegate : UIGestureRecognizerDelegate?
 
   // MARK: - MaterialHeader

--- a/ScienceJournal/UI/ObserveViewController.swift
+++ b/ScienceJournal/UI/ObserveViewController.swift
@@ -109,7 +109,8 @@ open class ObserveViewController: ScienceJournalCollectionViewController, ChartC
   let recordingManager: RecordingManager
   var recordingTrial: Trial?
   let sensorController: SensorController
-  @objc dynamic private(set) var isContentOutsideOfSafeArea: Bool = false
+  @objc private(set) lazy var scrollViewContentObserver
+    = ScrollViewContentObserver(scrollView: collectionView)
 
   // TODO: Refactor this out by more logically enabling/disabling the brightness listener.
   // http://b/64401602
@@ -1653,12 +1654,6 @@ open class ObserveViewController: ScienceJournalCollectionViewController, ChartC
   }
 
   // MARK: - UIScrollViewDelegate
-
-  open override func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    if isContentOutsideOfSafeArea != scrollView.isContentOutsideOfSafeArea {
-      isContentOutsideOfSafeArea = scrollView.isContentOutsideOfSafeArea
-    }
-  }
 
   override open func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
     drawerPanner?.scrollViewWillBeginDragging(scrollView)

--- a/ScienceJournal/UI/ObserveViewController.swift
+++ b/ScienceJournal/UI/ObserveViewController.swift
@@ -109,8 +109,8 @@ open class ObserveViewController: ScienceJournalCollectionViewController, ChartC
   let recordingManager: RecordingManager
   var recordingTrial: Trial?
   let sensorController: SensorController
-  @objc private(set) lazy var scrollViewContentObserver
-    = ScrollViewContentObserver(scrollView: collectionView)
+  @objc private(set) lazy var scrollViewContentObserver =
+    ScrollViewContentObserver(scrollView: collectionView)
 
   // TODO: Refactor this out by more logically enabling/disabling the brightness listener.
   // http://b/64401602

--- a/ScienceJournal/UI/ScrollViewContentObserver.swift
+++ b/ScienceJournal/UI/ScrollViewContentObserver.swift
@@ -1,0 +1,50 @@
+/*
+ *  Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import UIKit
+
+/// Observes a `UIScrollView`'s content size and offset properties,
+/// to determine whether its content is outside its safeArea.
+class ScrollViewContentObserver: NSObject {
+  @objc dynamic private(set) var isContentOutsideOfSafeArea: Bool = false
+  private weak var scrollView: UIScrollView?
+  private var contentSizeObserver: NSKeyValueObservation?
+  private var contentOffsetObserver: NSKeyValueObservation?
+
+  init(scrollView: UIScrollView?) {
+    super.init()
+    self.scrollView = scrollView
+
+    contentSizeObserver = scrollView?
+      .observe(\.contentSize, options: [.new]) { [weak self] _, _ in
+        self?.checkContentSafeArea()
+    }
+
+    contentOffsetObserver = scrollView?
+      .observe(\.contentOffset, options: [.new]) { [weak self] _, _ in
+        self?.checkContentSafeArea()
+    }
+  }
+
+  /// Sets `self.isContentOutsideOfSafeArea` to the appropriate value.
+  private func checkContentSafeArea() {
+    guard let scrollView = scrollView,
+      scrollView.isContentOutsideOfSafeArea != isContentOutsideOfSafeArea else {
+      return
+    }
+    isContentOutsideOfSafeArea = scrollView.isContentOutsideOfSafeArea
+  }
+}

--- a/ScienceJournal/UI/UserFlowViewController.swift
+++ b/ScienceJournal/UI/UserFlowViewController.swift
@@ -912,7 +912,7 @@ class UserFlowViewController: UIViewController, ExperimentsListViewControllerDel
       content: trialDetailViewController,
       emptyState: recordingDetailEmptyState,
       actionEnablingKeyPath: \.isEditable,
-      outsideOfSafeAreaKeyPath: \.isContentOutsideOfSafeArea,
+      outsideOfSafeAreaKeyPath: \.scrollViewContentObserver.isContentOutsideOfSafeArea,
       mode: .stateless(actionItem: ActionArea.ActionItem(
         items: [textItem, cameraItem, galleryItem]
       ))
@@ -957,7 +957,7 @@ class UserFlowViewController: UIViewController, ExperimentsListViewControllerDel
 
     let detail = ActionArea.DetailContentContainerViewController(
       content: experimentCoordinator.observeViewController,
-      outsideOfSafeAreaKeyPath: \.isContentOutsideOfSafeArea
+      outsideOfSafeAreaKeyPath: \.scrollViewContentObserver.isContentOutsideOfSafeArea
     ) {
       let addSensorItem = ActionArea.BarButtonItem(
         title: String.actionAreaButtonAddSensor,
@@ -1014,7 +1014,7 @@ class UserFlowViewController: UIViewController, ExperimentsListViewControllerDel
       content: experimentCoordinator,
       emptyState: emptyState,
       actionEnablingKeyPath: \.shouldAllowAdditions,
-      outsideOfSafeAreaKeyPath: \.isContentOutsideOfSafeArea,
+      outsideOfSafeAreaKeyPath: \.scrollViewContentObserver.isContentOutsideOfSafeArea,
       mode: .stateless(actionItem: ActionArea.ActionItem(
         items: [textItem, sensorsItem, cameraItem, galleryItem]
       ))


### PR DESCRIPTION
<!-- Thanks for contributing to Science Journal iOS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/google/science-journal-ios/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/google/science-journal-ios/blob/master/CHANGE_LIMITATIONS.md)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The `ActionArea.BarViewController` wasn't updating its appearance (raising or lowering a drop shadow) after certain events, like pushing/popping view controllers, or adding/removing/editing entries. (Only scrolling its content would update correctly.)

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

This PR:
- Adds an observer for `scrollView.contentSize` in addition to the `.contentOffset` when determining the `ActionArea`'s appearance.
- Moves the observer logic out of the scrollView delegate callbacks and into a `ScrollViewContentObserver` object.

I've tested various pushing/popping/editing of the `TrialDetailViewController` contents; if you think of any other edge cases, I'd be happy to test those as well.