### PR TITLE
Handle camera button based on camera status

### DIFF
--- a/ScienceJournal/Resources/Strings.bundle/en.lproj/Localizable.strings
+++ b/ScienceJournal/Resources/Strings.bundle/en.lproj/Localizable.strings
@@ -850,6 +850,12 @@
 /* Message informing a user they cannot use the camera because they denied Science Journal access to it in iOS. [CHAR_LIMIT=200] */
 "input_camera_permission_denied" = "The camera cannot be used because Science Journal does not have permission to access it.";
 
+/* Title of alert informing a user they cannot use the camera because they denied Science Journal access to it in iOS. [CHAR_LIMIT=40] */
+"input_camera_permission_denied_title" = "Camera Not Available";
+
+/* Message informing a user they cannot use the camera because they denied Science Journal access to it in iOS, with Settings button to change access. [CHAR_LIMIT=200] */
+"input_camera_permission_denied_settings" = "The camera cannot be used because Science Journal does not have permission to access it. You may change this in Settings.";
+
 /* Message informing a user they cannot view their photo library because they denied Science Journal access to it in iOS. [CHAR_LIMIT=200] */
 "input_photo_library_permission_denied" = "Your photo library cannot be used because Science Journal does not have permission to access it.";
 

--- a/ScienceJournal/Strings/ScienceJournalStrings.swift
+++ b/ScienceJournal/Strings/ScienceJournalStrings.swift
@@ -308,6 +308,8 @@ extension String {
   static public var inputCameraBlockedByInterruption: String { return "input_camera_blocked_by_interruption".localized }
   static public var inputCameraBlockedViewSensorsButton: String { return "input_camera_blocked_view_sensors_button".localized }
   static public var inputCameraPermissionDenied: String { return "input_camera_permission_denied".localized }
+  static public var inputCameraPermissionDeniedTitle: String { return "input_camera_permission_denied_title".localized }
+  static public var inputCameraPermissionDeniedSettings: String { return "input_camera_permission_denied_settings".localized }
   static public var inputPhotoLibraryPermissionDenied: String { return "input_photo_library_permission_denied".localized }
   static public var launchFailureMessage: String { return "launch_failure_message".localized }
   static public var launchFailureSendFeedbackButton: String { return "launch_failure_send_feedback_button".localized }

--- a/ScienceJournal/UI/ExperimentCoordinatorViewController.swift
+++ b/ScienceJournal/UI/ExperimentCoordinatorViewController.swift
@@ -1710,7 +1710,39 @@ class ExperimentCoordinatorViewController: MaterialHeaderViewController, DrawerP
   }
 
   func cameraButtonPressed() {
-    present(cameraImageProvider.cameraViewController, animated: true, completion: nil)
+    switch CaptureSessionInterruptionObserver.shared.cameraAvailability {
+    case .permissionsDenied:
+      showCameraPermissionsDeniedAlert()
+    case .blockedByBrightnessSensor:
+      showSnackbar(withMessage: String.inputCameraBlockedByBrightnessSensor,
+                   category: nil,
+                   actionTitle: String.actionOk,
+                   actionHandler: nil
+      )
+    default: // Handles .available and .captureInterrupted
+      present(cameraImageProvider.cameraViewController, animated: true)
+    }
+  }
+
+  func showCameraPermissionsDeniedAlert() {
+    let ac = UIAlertController(title: String.inputCameraPermissionDeniedTitle,
+                               message: String.inputCameraPermissionDeniedSettings,
+                               preferredStyle: .alert)
+
+    let settingsAction = UIAlertAction(title: String.actionSettings,
+                                       style: .default) { _ in
+      if let settingsURL = URL(string: "App-prefs:root=Privacy&path=CAMERA") {
+        UIApplication.shared.open(settingsURL)
+      }
+    }
+    ac.addAction(settingsAction)
+
+    let cancelAction = UIAlertAction(title: String.actionCancel,
+                                     style: .cancel,
+                                     handler: nil)
+    ac.addAction(cancelAction)
+
+    present(ac, animated: true)
   }
 
   // MARK: - Notifications

--- a/ScienceJournal/UI/TrialDetailViewController.swift
+++ b/ScienceJournal/UI/TrialDetailViewController.swift
@@ -1758,9 +1758,40 @@ class TrialDetailViewController: MaterialHeaderViewController,
   }
 
   func cameraButtonPressed() {
-    present(cameraImageProvider.cameraViewController, animated: true, completion: nil)
+    switch CaptureSessionInterruptionObserver.shared.cameraAvailability {
+    case .permissionsDenied:
+      showCameraPermissionsDeniedAlert()
+    case .blockedByBrightnessSensor:
+      showSnackbar(withMessage: String.inputCameraBlockedByBrightnessSensor,
+                   category: nil,
+                   actionTitle: String.actionOk,
+                   actionHandler: nil
+      )
+    default: // Handles .available and .captureInterrupted
+      present(cameraImageProvider.cameraViewController, animated: true)
+    }
   }
 
+  func showCameraPermissionsDeniedAlert() {
+    let ac = UIAlertController(title: String.inputCameraPermissionDeniedTitle,
+                               message: String.inputCameraPermissionDeniedSettings,
+                               preferredStyle: .alert)
+
+    let settingsAction = UIAlertAction(title: String.actionSettings,
+                                       style: .default) { _ in
+      if let settingsURL = URL(string: "App-prefs:root=Privacy&path=CAMERA") {
+        UIApplication.shared.open(settingsURL)
+      }
+    }
+    ac.addAction(settingsAction)
+
+    let cancelAction = UIAlertAction(title: String.actionCancel,
+                                     style: .cancel,
+                                     handler: nil)
+    ac.addAction(cancelAction)
+
+    present(ac, animated: true)
+  }
 }
 
 // MARK: - NotesViewControllerDelegate


### PR DESCRIPTION
<!-- Thanks for contributing to Science Journal iOS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/google/science-journal-ios/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/google/science-journal-ios/blob/master/CHANGE_LIMITATIONS.md)

### Motivation and Context
When tapped, the camera button in the new action area presented the system camera UI (via `UIImagePickerController`) without checking camera permissions first. If permissions were not determined or denied, this presented the camera UI with a black background, without explaining why the camera wasn't working.

In addition, the camera button did not have any handling for the case were the brightness sensor was already in use, preventing the use of the camera.

### Description

* Added the `CameraAvailability` enum and the `cameraAvailability` property to `CaptureSessionInterruptionObserver`, to provide a more nuanced and actionable result than the existing `isCameraUseAllowed` Bool.
* Updated the `ExperimentCoordinatorViewController` and `TrialDetailViewController` to check the new enum property, and handle denied camera permission and brightness sensor limitations before presenting the camera UI.
* Added a Settings button on the permissions denied alert which will navigate to Settings -> Privacy -> Camera when tapped.
* Allowed use of the camera while multitasking, which would have been prevented in some scenarios by using the `isCameraUseAllowed` Bool.
* Created strings to support the new handling of permission denied.
* Added a note about potentially unexpected values for `isCaptureSessionInterrupted` if it is expected to be a proxy for whether the app is running in a multitasking context or not.

Changes were tested on iOS devices running running iOS 12.4.1 and iPadOS 13, turning permissions on and off, testing with and without the brightness sensor in use, and testing in multitasking modes.