### PR TITLE
Fix card offset animation when recording

### DIFF
--- a/ScienceJournal/UI/ObserveViewController.swift
+++ b/ScienceJournal/UI/ObserveViewController.swift
@@ -884,6 +884,10 @@ open class ObserveViewController: ScienceJournalCollectionViewController, ChartC
           UIView.layoutFittingCompressedSize).height : 0
       collectionView?.contentInset.top = topInset
       collectionView?.scrollIndicatorInsets.top = topInset
+      if collectionView?.contentOffset.y == 0 {
+        // Adjusts the offset so the timeAxisView doesn't obscure the top-most card
+        collectionView?.contentOffset.y = -topInset
+      }
     } else {
       var bottomInset =
         recordButtonViewWrapper.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
@@ -898,10 +902,16 @@ open class ObserveViewController: ScienceJournalCollectionViewController, ChartC
 
   // Animates the display of the time axis view.
   func showTimeAxisView(_ isVisible: Bool) {
-    UIView.animate(withDuration: 0.5, animations: {
-      self.timeAxisController.timeAxisView.alpha = isVisible ? 1 : 0
-    }) { (_) in
-      self.adjustContentInsets()
+    if FeatureFlags.isActionAreaEnabled {
+      self.transitionCoordinator?.animate(alongsideTransition: { _ in
+        self.timeAxisController.timeAxisView.alpha = isVisible ? 1 : 0
+        self.adjustContentInsets()
+      }, completion: nil)
+    } else {
+      UIView.animate(withDuration: 0.4) {
+        self.timeAxisController.timeAxisView.alpha = isVisible ? 1 : 0
+        self.adjustContentInsets()
+      }
     }
   }
 

--- a/ScienceJournal/UI/ObserveViewController.swift
+++ b/ScienceJournal/UI/ObserveViewController.swift
@@ -884,7 +884,8 @@ open class ObserveViewController: ScienceJournalCollectionViewController, ChartC
           UIView.layoutFittingCompressedSize).height : 0
       collectionView?.contentInset.top = topInset
       collectionView?.scrollIndicatorInsets.top = topInset
-      if collectionView?.contentOffset.y == 0 {
+      if FeatureFlags.isActionAreaEnabled,
+        collectionView?.contentOffset.y == 0 {
         // Adjusts the offset so the timeAxisView doesn't obscure the top-most card
         collectionView?.contentOffset.y = -topInset
       }
@@ -906,7 +907,7 @@ open class ObserveViewController: ScienceJournalCollectionViewController, ChartC
       self.transitionCoordinator?.animate(alongsideTransition: { _ in
         self.timeAxisController.timeAxisView.alpha = isVisible ? 1 : 0
         self.adjustContentInsets()
-      }, completion: nil)
+      })
     } else {
       UIView.animate(withDuration: 0.4) {
         self.timeAxisController.timeAxisView.alpha = isVisible ? 1 : 0


### PR DESCRIPTION
<!-- Thanks for contributing to Science Journal iOS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/google/science-journal-ios/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/google/science-journal-ios/blob/master/CHANGE_LIMITATIONS.md)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When entering record mode, the cards wouldn't animate to below the `TimeAxisView`, which resulted in ugly overlap.

<img width="429" alt="iPad Pro (11-inch) — 13 1 2019-10-10 13-49-21" src="https://user-images.githubusercontent.com/1952578/66605382-dc7dce00-eb64-11e9-8f33-91ec8e876caf.png">


### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

This PR
- Animates the content adjustment (previously it was in the animation's completion block).
- Uses separate animation patterns based on the `isActionAreaEnabled` feature flag.
- Manually offsets the `collectionView` (unless the user has scrolled past `offset.y == 0`), so that the top-most card is pushed down below the `TimeAxisView`.

<img width="430" alt="iPad Pro (11-inch) — 13 1 2019-10-10 13-49-32" src="https://user-images.githubusercontent.com/1952578/66605390-e1428200-eb64-11e9-90b3-1e1b3e7bc6f2.png">


(I tried to record a video, but it's too choppy and you can't see the animation anyway.)