### PR TITLE
Enable or disable the “Add Sensors” button

### DIFF
--- a/ScienceJournal/ActionArea/ActionAreaBarButtonItem.swift
+++ b/ScienceJournal/ActionArea/ActionAreaBarButtonItem.swift
@@ -43,6 +43,7 @@ extension ActionArea {
     private(set) var title: String
     private(set) var image: UIImage?
     private(set) var action: () -> Void // TODO: Consider passing the AA controller here.
+    private(set) var enabler: FeatureEnabler?
 
     /// Designated initializer.
     ///
@@ -50,10 +51,16 @@ extension ActionArea {
     ///   - title: The title for the item.
     ///   - accessibilityHint: The accessibility hint for the item.
     ///   - image: The image for the item.
+    ///   - enabler: A feature enabler to handle changes in an observed Bool value.
     ///   - action: A block to execute when the item is tapped.
-    init(title: String, accessibilityHint: String?, image: UIImage?, action: @escaping () -> Void) {
+    init(title: String,
+         accessibilityHint: String?,
+         image: UIImage?,
+         enabler: FeatureEnabler? = nil,
+         action: @escaping () -> Void) {
       self.title = title
       self.image = image
+      self.enabler = enabler
       self.action = action
       super.init()
       self.accessibilityHint = accessibilityHint

--- a/ScienceJournal/ActionArea/ActionAreaBarViewController.swift
+++ b/ScienceJournal/ActionArea/ActionAreaBarViewController.swift
@@ -429,6 +429,12 @@ extension ActionArea {
         (stackView.arrangedSubviews.count ..< 4).forEach { _ in
           stackView.addArrangedSubview(UIView())
         }
+
+        items.forEach { (item) in
+          item.enabler?.observe({ (enabled) in
+            self.setButtonFor(item: item, enabled: enabled)
+          })
+        }
       }
     }
 
@@ -448,8 +454,12 @@ extension ActionArea {
       fatalError("init(coder:) has not been implemented")
     }
 
+    func setButtonFor(item: BarButtonItem, enabled: Bool, animated: Bool = true) {
+      if let index = items.index(of: item) {
+        buttons[index].setEnabled(enabled, animated: animated)
+      }
+    }
   }
-
 }
 
 // MARK: - ActionArea.BarButton
@@ -527,8 +537,20 @@ extension ActionArea {
       button.backgroundColor = customTint.secondary
     }
 
+    func setEnabled(_ enabled: Bool, animated: Bool = true) {
+      button.isEnabled = enabled
+      let updatedAlpha: CGFloat = enabled ? 1.0 : BarViewController.Metrics.Bar.disabledAlpha
+      if animated {
+        UIView.animate(withDuration: 0.5) {
+          self.button.alpha = updatedAlpha
+          self.label.alpha = updatedAlpha
+        }
+      } else {
+        self.button.alpha = updatedAlpha
+        self.label.alpha = updatedAlpha
+      }
+    }
   }
-
 }
 
 // MARK: - Debugging

--- a/ScienceJournal/UI/ObserveViewController.swift
+++ b/ScienceJournal/UI/ObserveViewController.swift
@@ -176,6 +176,8 @@ open class ObserveViewController: ScienceJournalCollectionViewController, ChartC
     return self.observeDataSource.availableSensorIDs
   }
 
+  @objc dynamic private(set) var unusedSensors: Bool = false
+
   // MARK: - Public
 
   /// Designated initializer.
@@ -197,6 +199,7 @@ open class ObserveViewController: ScienceJournalCollectionViewController, ChartC
 
     let flowLayout = MDCCollectionViewFlowLayout()
     flowLayout.minimumLineSpacing = SensorCardCell.cardInsets.bottom
+
     super.init(collectionViewLayout: flowLayout, analyticsReporter: analyticsReporter)
 
     observeDataSource.delegate = self
@@ -757,6 +760,10 @@ open class ObserveViewController: ScienceJournalCollectionViewController, ChartC
     sensorCard.toneGenerator.stop()
   }
 
+  private func updateUnusedSensors() {
+    unusedSensors = observeDataSource.items.count < sensorController.availableSensors.count
+  }
+
   private func removeSensorCardCell(_ cell: SensorCardCell) {
     guard let indexPath = collectionView?.indexPath(for: cell) else {
       return
@@ -780,7 +787,7 @@ open class ObserveViewController: ScienceJournalCollectionViewController, ChartC
       }
     }, completion: { (_) in
       self.updateSensorPickersIfNeeded()
-      // TODO: Show/Enable the "Add Sensor" button if needed
+      self.updateUnusedSensors()
     })
   }
 
@@ -809,7 +816,7 @@ open class ObserveViewController: ScienceJournalCollectionViewController, ChartC
         self.collectionView?.deleteSections(IndexSet(integer: previousFooterIndexPath.section))
       }
     }, completion: { (_) in
-      // TODO: Hide/Disable the "Add Sensor" button.
+      self.updateUnusedSensors()
     })
     collectionView?.scrollToItem(at: IndexPath(item: newItemIndexPath.item, section: 0),
                                  at: .top,
@@ -1028,6 +1035,7 @@ open class ObserveViewController: ScienceJournalCollectionViewController, ChartC
     addInitialSensorCardIfNeeded(andAddListener: andAddListeners)
 
     collectionView?.reloadData()
+    updateUnusedSensors()
   }
 
   /// Sets the available sensors for the current experiment.

--- a/ScienceJournal/UI/UserFlowViewController.swift
+++ b/ScienceJournal/UI/UserFlowViewController.swift
@@ -962,7 +962,9 @@ class UserFlowViewController: UIViewController, ExperimentsListViewControllerDel
       let addSensorItem = ActionArea.BarButtonItem(
         title: String.actionAreaButtonAddSensor,
         accessibilityHint: String.actionAreaButtonAddSensorContentDescription,
-        image: UIImage(named: "ic_action_area_add_sensor")
+        image: UIImage(named: "ic_action_area_add_sensor"),
+        enabler: FeatureEnabler(target: experimentCoordinator.observeViewController,
+                                keyPath: \.unusedSensors)
       ) {
         experimentCoordinator.observeViewController.observeFooterAddButtonPressed()
       }


### PR DESCRIPTION
<!-- Thanks for contributing to Science Journal iOS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/google/science-journal-ios/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/google/science-journal-ios/blob/master/CHANGE_LIMITATIONS.md)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
The "Add Sensor" button in the action area remains enabled, even when there are no additional sensors to add. This could be confusing for users. The visual characteristics and interactivity of the "Add Sensor" button should change based on whether there are unused sensors available for the device.

<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

* Added an `unusedSensors` `Bool` to `ObserveViewController` to store the current state of sensors that are available but not currently in use.
* Added an `enabler` property to `BarButtonItem` to handle KVO observations of `Bool` properties.
* Specified `enabler` for the "Add Sensor" bar button item, to observe changes to `ObserveViewController`'s `unusedSensors` property.
* Added a `setButtonFor(item:enabled:animated:)` method to the `ActionArea.Bar` to toggle enabled for buttons based on observations received by a `BarButtonItem`.
* Added a `setEnabled(_:animated:)` method on the `BarButton` to change the interactivity and alpha of its subviews.

<!-- Please describe in detail how you tested your changes. -->
Tested in the simulator and on devices running iOS 12 and 13.