### PR TITLE
Clarified sequence of steps to set up build environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,19 @@ First, you'll need a Mac. We don't support building the iOS app on anything else
 
 Second, you'll need the latest version of [Xcode](https://developer.apple.com/xcode/) installed.
 
-Third, we use a few open source frameworks to build this app, so you'll need to install CocoaPods as your package manager in order to get what you need to build.
+Third, we use a few open source frameworks to build this app, so you'll need to install [CocoaPods](https://cocoapods.org/) as your package manager in order to get what you need to build.
 
-Fourth, we use [protobuf](https://developers.google.com/protocol-buffers/). You'll need to install that too. We use [Homebrew](https://brew.sh/) to install it:
-`brew install protobuf@3.1; brew link protobuf@3.1 -f`.
+Fourth, we use [protobuf](https://developers.google.com/protocol-buffers/). You'll need to install that too. We use [Homebrew](https://brew.sh/) to install it.
 
-We recommend installing [CocoaPods](https://cocoapods.org/) by running:
-`sudo gem install cocoapods` from your terminal.
+Here are the steps to set up your environment:
+
+1. Install Xcode.
+2. Install CocoaPods by running `sudo gem install cocoapods` from your terminal.
+3. Install Homebrew by following the instructions on the [Homebrew website](https://brew.sh/).
+4. Install protobuf by running `brew install protobuf@3.1; brew link protobuf@3.1 -f` from your terminal.
 
 ## Building and running
-Before you jump into coding, you'll need to run
-
-`pod install` from the root of this project (the folder that contains has the `Podfile` file)
+Before you jump into coding, you'll need to run `pod install` from the root of this project (the folder that contains has the `Podfile` file)
 
 Then you can open `ScienceJournal.xcworkspace`
 


### PR DESCRIPTION
<!-- Thanks for contributing to Science Journal iOS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/google/science-journal-ios/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/google/science-journal-ios/blob/master/CHANGE_LIMITATIONS.md)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

The existing instructions do not make the dependency of the CocoaPods process on protobuf explicit. If you run `pod install` before `protobuf` has been installed, the installation fails because the [`post_install`](https://github.com/google/science-journal-ios/blob/master/Podfile#L66) method in the `Podfile` makes use of `protobuf`.

### Description
 
Changes include:

* Listed all the dependencies using the current format.
* Consolidated the two lines which mention CocoaPods into the paragraph that starts with "Third".
* Added a numbered list of steps to set up the environment, clarifying that `protobuf` should be installed before proceeding to the `pod install` command in the Building and Running section.

I tested this on a Mac that did not originally have `protobuf` installed.
