### PR TITLE
imageSelectorDidCreateImageData refactor

### DIFF
--- a/ScienceJournal.xcodeproj/project.pbxproj
+++ b/ScienceJournal.xcodeproj/project.pbxproj
@@ -3040,7 +3040,7 @@
 					68EBA6D91E20421E0089FF7F = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = EQHXZ8M8AV;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1110;
 						ProvisioningStyle = Manual;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
@@ -3050,13 +3050,13 @@
 					};
 					68EBA6ED1E20421E0089FF7F = {
 						CreatedOnToolsVersion = 8.2.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1110;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 68EBA6D91E20421E0089FF7F;
 					};
 					68EBA6F81E20421E0089FF7F = {
 						CreatedOnToolsVersion = 8.2.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1110;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 68EBA6D91E20421E0089FF7F;
 					};
@@ -4098,7 +4098,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT = 0;
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/Pods/MaterialComponents/components/** $(SRCROOT)/Pods/GoogleAPIClientForREST/** $(SRCROOT)/Pods/GTMSessionFetcher $(SRCROOT)/Pods/GTMOAuth2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -4128,7 +4128,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournal.ScienceJournalTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ScienceJournal.app/ScienceJournal";
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Pods/MaterialComponents/components\"/**";
 			};
@@ -4157,7 +4157,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournalUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = ScienceJournal;
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Pods/MaterialComponents/components\"/**";
 			};
@@ -4283,7 +4283,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "Science Journal Dev";
 				SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT = 0;
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/Pods/MaterialComponents/components/** $(SRCROOT)/Pods/GoogleAPIClientForREST/** $(SRCROOT)/Pods/GTMSessionFetcher $(SRCROOT)/Pods/GTMOAuth2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -4313,7 +4313,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournal.ScienceJournalTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ScienceJournal.app/ScienceJournal";
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Pods/MaterialComponents/components\"/**";
 			};
@@ -4342,7 +4342,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournalUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = ScienceJournal;
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Pods/MaterialComponents/components\"/**";
 			};
@@ -4530,7 +4530,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "Science Journal Dev";
 				SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT = 3;
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/Pods/MaterialComponents/components/** $(SRCROOT)/Pods/GoogleAPIClientForREST/** $(SRCROOT)/Pods/GTMSessionFetcher $(SRCROOT)/Pods/GTMOAuth2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -4585,7 +4585,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "Science Journal Dev";
 				SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT = 0;
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/Pods/MaterialComponents/components/** $(SRCROOT)/Pods/GoogleAPIClientForREST/** $(SRCROOT)/Pods/GTMSessionFetcher $(SRCROOT)/Pods/GTMOAuth2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -4616,7 +4616,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ScienceJournal.app/ScienceJournal";
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Pods/MaterialComponents/components\"/**";
 			};
@@ -4646,7 +4646,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournal.ScienceJournalTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ScienceJournal.app/ScienceJournal";
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Pods/MaterialComponents/components\"/**";
 			};
@@ -4676,7 +4676,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = ScienceJournal;
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Pods/MaterialComponents/components\"/**";
 			};
@@ -4705,7 +4705,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.opensource.ScienceJournalUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_INCLUDE_PATHS = "\"$(SRCROOT)/ModuleMaps\"/**";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = ScienceJournal;
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Pods/MaterialComponents/components\"/**";
 			};

--- a/ScienceJournal/UI/CameraViewController.swift
+++ b/ScienceJournal/UI/CameraViewController.swift
@@ -374,7 +374,7 @@ open class CameraViewController: ScienceJournalViewController, DrawerItemViewCon
   // MARK: - Private
 
   private func handleImageDataSelected(_ imageData: Data, metadata: NSDictionary?) {
-    delegate?.imageSelectorDidCreateImageData(imageData, metadata: metadata)
+    delegate?.imageSelectorDidCreateImageData([(imageData, metadata)])
     drawerViewController?.minimizeFromFull()
 
     // TODO: Consider AA-specific API.

--- a/ScienceJournal/UI/CameraViewController.swift
+++ b/ScienceJournal/UI/CameraViewController.swift
@@ -374,7 +374,7 @@ open class CameraViewController: ScienceJournalViewController, DrawerItemViewCon
   // MARK: - Private
 
   private func handleImageDataSelected(_ imageData: Data, metadata: NSDictionary?) {
-    delegate?.imageSelectorDidCreateImageData([(imageData, metadata)])
+    delegate?.imageSelectorDidCreateImageData([ImageData(imageData: imageData, metadata: metadata)])
     drawerViewController?.minimizeFromFull()
 
     // TODO: Consider AA-specific API.

--- a/ScienceJournal/UI/EditExperimentPhotoLibraryViewController.swift
+++ b/ScienceJournal/UI/EditExperimentPhotoLibraryViewController.swift
@@ -72,7 +72,7 @@ class EditExperimentPhotoLibraryViewController: MaterialHeaderViewController,
   }
 
   // MARK: - ImageSelectorDelegate
-  func imageSelectorDidCreateImageData(_ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
+  func imageSelectorDidCreateImageData(_ imageDatas: [ImageData]) {
     guard imageDatas.count == 1 else {
       fatalError("Only one image can be selected for the experiment cover.")
     }

--- a/ScienceJournal/UI/EditExperimentPhotoLibraryViewController.swift
+++ b/ScienceJournal/UI/EditExperimentPhotoLibraryViewController.swift
@@ -72,8 +72,7 @@ class EditExperimentPhotoLibraryViewController: MaterialHeaderViewController,
   }
 
   // MARK: - ImageSelectorDelegate
-  func imageSelectorDidCreateImageData(
-    _ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
+  func imageSelectorDidCreateImageData(_ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
     guard imageDatas.count == 1 else {
       fatalError("Only one image can be selected for the experiment cover.")
     }

--- a/ScienceJournal/UI/EditExperimentPhotoLibraryViewController.swift
+++ b/ScienceJournal/UI/EditExperimentPhotoLibraryViewController.swift
@@ -73,8 +73,9 @@ class EditExperimentPhotoLibraryViewController: MaterialHeaderViewController,
 
   // MARK: - ImageSelectorDelegate
   func imageSelectorDidCreateImageData(_ imageDatas: [ImageData]) {
-    guard imageDatas.count == 1 else {
-      fatalError("Only one image can be selected for the experiment cover.")
+    if imageDatas.count > 1 {
+      sjlog_info("[EditExperimentPhotoLibraryViewController] More than 1 ImageData.",
+                 category: .general)
     }
 
     delegate?.imageSelectorDidCreateImageData(imageDatas)

--- a/ScienceJournal/UI/EditExperimentPhotoLibraryViewController.swift
+++ b/ScienceJournal/UI/EditExperimentPhotoLibraryViewController.swift
@@ -72,15 +72,14 @@ class EditExperimentPhotoLibraryViewController: MaterialHeaderViewController,
   }
 
   // MARK: - ImageSelectorDelegate
-
-  func imageSelectorDidCreateImageData(_ imageData: Data, metadata: NSDictionary?) {
-    delegate?.imageSelectorDidCreateImageData(imageData, metadata: metadata)
-    dismiss(animated: true)
-  }
-
-  func imageSelectorDidCreateMultipleImageDatas(
+  func imageSelectorDidCreateImageData(
     _ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
-    // This view controller does not allow selecting multiple images.
+    guard imageDatas.count == 1 else {
+      fatalError("Only one image can be selected for the experiment cover.")
+    }
+
+    delegate?.imageSelectorDidCreateImageData(imageDatas)
+    dismiss(animated: true)
   }
 
   func imageSelectorDidCancel() {}

--- a/ScienceJournal/UI/EditExperimentViewController.swift
+++ b/ScienceJournal/UI/EditExperimentViewController.swift
@@ -232,16 +232,14 @@ class EditExperimentViewController: MaterialHeaderViewController, EditExperiment
   func imageSelectorDidCreateImageData(_ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
     // Check if the photo can be saved before proceeding. Normally this happens lower in the stack
     // but we do it here because it is currently not possible to pass the error up the UI to here.
-    guard imageDatas.count == 1,
-        let imageData = imageDatas.first?.imageData,
-        let metadata = imageDatas.first?.metadata else {
+    guard imageDatas.count == 1, let imageDataTuple = imageDatas.first else {
       fatalError("Only one image can be selected for the edit experiment vc.")
     }
 
-    if metadataManager.canSave(imageData) {
-      guard let image = UIImage(data: imageData) else { return }
+    if metadataManager.canSave(imageDataTuple.imageData) {
+      guard let image = UIImage(data: imageDataTuple.imageData) else { return }
       photoPicker.photo = image
-      selectedImageInfo = (imageData, metadata)
+      selectedImageInfo = imageDataTuple
     } else {
       dismiss(animated: true) {
         showSnackbar(withMessage: String.photoDiskSpaceErrorMessage)

--- a/ScienceJournal/UI/EditExperimentViewController.swift
+++ b/ScienceJournal/UI/EditExperimentViewController.swift
@@ -229,8 +229,7 @@ class EditExperimentViewController: MaterialHeaderViewController, EditExperiment
 
   // MARK: - ImageSelectorDelegate
 
-  func imageSelectorDidCreateImageData(
-    _ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
+  func imageSelectorDidCreateImageData(_ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
     // Check if the photo can be saved before proceeding. Normally this happens lower in the stack
     // but we do it here because it is currently not possible to pass the error up the UI to here.
     guard imageDatas.count == 1,

--- a/ScienceJournal/UI/EditExperimentViewController.swift
+++ b/ScienceJournal/UI/EditExperimentViewController.swift
@@ -229,9 +229,16 @@ class EditExperimentViewController: MaterialHeaderViewController, EditExperiment
 
   // MARK: - ImageSelectorDelegate
 
-  func imageSelectorDidCreateImageData(_ imageData: Data, metadata: NSDictionary?) {
+  func imageSelectorDidCreateImageData(
+    _ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
     // Check if the photo can be saved before proceeding. Normally this happens lower in the stack
     // but we do it here because it is currently not possible to pass the error up the UI to here.
+    guard imageDatas.count == 1,
+        let imageData = imageDatas.first?.imageData,
+        let metadata = imageDatas.first?.metadata else {
+      fatalError("Only one image can be selected for the edit experiment vc.")
+    }
+
     if metadataManager.canSave(imageData) {
       guard let image = UIImage(data: imageData) else { return }
       photoPicker.photo = image
@@ -241,11 +248,6 @@ class EditExperimentViewController: MaterialHeaderViewController, EditExperiment
         showSnackbar(withMessage: String.photoDiskSpaceErrorMessage)
       }
     }
-  }
-
-  func imageSelectorDidCreateMultipleImageDatas(
-    _ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
-    // This view controller does not allow selecting multiple images.
   }
 
   func imageSelectorDidCancel() {}

--- a/ScienceJournal/UI/EditExperimentViewController.swift
+++ b/ScienceJournal/UI/EditExperimentViewController.swift
@@ -229,7 +229,7 @@ class EditExperimentViewController: MaterialHeaderViewController, EditExperiment
 
   // MARK: - ImageSelectorDelegate
 
-  func imageSelectorDidCreateImageData(_ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
+  func imageSelectorDidCreateImageData(_ imageDatas: [ImageData]) {
     // Check if the photo can be saved before proceeding. Normally this happens lower in the stack
     // but we do it here because it is currently not possible to pass the error up the UI to here.
     guard imageDatas.count == 1, let imageDataTuple = imageDatas.first else {

--- a/ScienceJournal/UI/EditExperimentViewController.swift
+++ b/ScienceJournal/UI/EditExperimentViewController.swift
@@ -232,8 +232,14 @@ class EditExperimentViewController: MaterialHeaderViewController, EditExperiment
   func imageSelectorDidCreateImageData(_ imageDatas: [ImageData]) {
     // Check if the photo can be saved before proceeding. Normally this happens lower in the stack
     // but we do it here because it is currently not possible to pass the error up the UI to here.
-    guard imageDatas.count == 1, let imageDataTuple = imageDatas.first else {
-      fatalError("Only one image can be selected for the edit experiment vc.")
+    guard let imageDataTuple = imageDatas.first else {
+      sjlog_info("[EditExperimentViewController] No imageData in imageSelectorDidCreateImageData.",
+                 category: .general)
+      return
+    }
+
+    if imageDatas.count > 1 {
+      sjlog_info("[EditExperimentViewController] More than 1 ImageData.", category: .general)
     }
 
     if metadataManager.canSave(imageDataTuple.imageData) {

--- a/ScienceJournal/UI/ExperimentCoordinatorViewController.swift
+++ b/ScienceJournal/UI/ExperimentCoordinatorViewController.swift
@@ -822,11 +822,7 @@ class ExperimentCoordinatorViewController: MaterialHeaderViewController, DrawerP
 
   // MARK: - ImageSelectorDelegate
 
-  func imageSelectorDidCreateImageData(_ imageData: Data, metadata: NSDictionary?) {
-    createPictureNote(imageData, metadata: metadata)
-  }
-
-  func imageSelectorDidCreateMultipleImageDatas(
+  func imageSelectorDidCreateImageData(
     _ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
     createPictureNotes(from: imageDatas)
   }
@@ -1082,7 +1078,7 @@ class ExperimentCoordinatorViewController: MaterialHeaderViewController, DrawerP
   }
 
   func cameraImageProviderDidPick(imageData: Data, metadata: NSDictionary?) {
-    createPictureNote(imageData, metadata: metadata)
+    createPictureNotes(from: [(imageData, metadata)])
     dismiss(animated: true, completion: nil)
   }
 
@@ -1481,10 +1477,6 @@ class ExperimentCoordinatorViewController: MaterialHeaderViewController, DrawerP
   /// Updates the title in the nav bar based on the current experiment.
   private func updateExperimentTitle() {
     title = experiment.title ?? String.localizedUntitledExperiment
-  }
-
-  private func createPictureNote(_ imageData: Data, metadata: NSDictionary?) {
-    createPictureNotes(from: [(imageData, metadata)])
   }
 
   private func createPictureNotes(from imageSet: [(imageData: Data, metadata: NSDictionary?)]) {

--- a/ScienceJournal/UI/ExperimentCoordinatorViewController.swift
+++ b/ScienceJournal/UI/ExperimentCoordinatorViewController.swift
@@ -1077,7 +1077,7 @@ class ExperimentCoordinatorViewController: MaterialHeaderViewController, DrawerP
   }
 
   func cameraImageProviderDidPick(imageData: Data, metadata: NSDictionary?) {
-    createPictureNotes(from: [(imageData, metadata)])
+    createPictureNotes(from: [ImageData(imageData: imageData, metadata: metadata)])
     dismiss(animated: true, completion: nil)
   }
 

--- a/ScienceJournal/UI/ExperimentCoordinatorViewController.swift
+++ b/ScienceJournal/UI/ExperimentCoordinatorViewController.swift
@@ -822,7 +822,7 @@ class ExperimentCoordinatorViewController: MaterialHeaderViewController, DrawerP
 
   // MARK: - ImageSelectorDelegate
 
-  func imageSelectorDidCreateImageData(_ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
+  func imageSelectorDidCreateImageData(_ imageDatas: [ImageData]) {
     createPictureNotes(from: imageDatas)
   }
 

--- a/ScienceJournal/UI/ExperimentCoordinatorViewController.swift
+++ b/ScienceJournal/UI/ExperimentCoordinatorViewController.swift
@@ -822,8 +822,7 @@ class ExperimentCoordinatorViewController: MaterialHeaderViewController, DrawerP
 
   // MARK: - ImageSelectorDelegate
 
-  func imageSelectorDidCreateImageData(
-    _ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
+  func imageSelectorDidCreateImageData(_ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
     createPictureNotes(from: imageDatas)
   }
 

--- a/ScienceJournal/UI/ImageSelectorDelegate.swift
+++ b/ScienceJournal/UI/ImageSelectorDelegate.swift
@@ -20,9 +20,11 @@ import UIKit
 /// or picked for a note.
 protocol ImageSelectorDelegate: class {
 
+  typealias ImageData = (imageData: Data, metadata: NSDictionary?)
+
   /// Tells the delegate that one or more image datas have been created, each with an optional
   /// metadata.
-  func imageSelectorDidCreateImageData(_ imageDatas: [(imageData: Data, metadata: NSDictionary?)])
+  func imageSelectorDidCreateImageData(_ imageDatas: [ImageData])
 
   /// Tells the delegate image selection was cancelled.
   func imageSelectorDidCancel()

--- a/ScienceJournal/UI/ImageSelectorDelegate.swift
+++ b/ScienceJournal/UI/ImageSelectorDelegate.swift
@@ -20,13 +20,9 @@ import UIKit
 /// or picked for a note.
 protocol ImageSelectorDelegate: class {
 
-  /// Tells the delegate image data has been created, with optional metadata.
-  func imageSelectorDidCreateImageData(_ imageData: Data, metadata: NSDictionary?)
-
-  /// Tells the delegate that multiple image datas have been created,
-  /// each with an optional metadata.
-  func imageSelectorDidCreateMultipleImageDatas(
-    _ imageDatas: [(imageData: Data, metadata: NSDictionary?)])
+  /// Tells the delegate that one or more image datas have been created, each with an optional
+  /// metadata.
+  func imageSelectorDidCreateImageData(_ imageDatas: [(imageData: Data, metadata: NSDictionary?)])
 
   /// Tells the delegate image selection was cancelled.
   func imageSelectorDidCancel()

--- a/ScienceJournal/UI/ImageSelectorDelegate.swift
+++ b/ScienceJournal/UI/ImageSelectorDelegate.swift
@@ -16,11 +16,11 @@
 
 import UIKit
 
+typealias ImageData = (imageData: Data, metadata: NSDictionary?)
+
 /// Delegate protocol for the camera and photo library to communicate when an image has been created
 /// or picked for a note.
 protocol ImageSelectorDelegate: class {
-
-  typealias ImageData = (imageData: Data, metadata: NSDictionary?)
 
   /// Tells the delegate that one or more image datas have been created, each with an optional
   /// metadata.

--- a/ScienceJournal/UI/PhotoLibraryViewController.swift
+++ b/ScienceJournal/UI/PhotoLibraryViewController.swift
@@ -590,7 +590,7 @@ open class PhotoLibraryViewController: ScienceJournalViewController, UICollectio
         print("[PhotoLibraryViewController] Error creating image data.")
         return
       }
-      self.delegate?.imageSelectorDidCreateMultipleImageDatas(imageDatas)
+      self.delegate?.imageSelectorDidCreateImageData(imageDatas)
       self.deselectAllPhotoAssets()
     }
 

--- a/ScienceJournal/UI/TrialDetailViewController.swift
+++ b/ScienceJournal/UI/TrialDetailViewController.swift
@@ -1003,8 +1003,12 @@ class TrialDetailViewController: MaterialHeaderViewController,
   // MARK: - ImageSelectorDelegate
 
   func imageSelectorDidCreateImageData(_ imageDatas: [ImageData]) {
-    guard imageDatas.count == 1, let imageDataTuple = imageDatas.first else {
-        fatalError("Only one image can be selected for the trial detail vc.")
+    guard let imageDataTuple = imageDatas.first else {
+      fatalError("Must have at least one image for [TrialDetailViewController].")
+    }
+
+    if imageDatas.count > 1 {
+      sjlog_info("[TrialDetailViewController] More than 1 ImageData.", category: .general)
     }
 
     let imageData = imageDataTuple.imageData

--- a/ScienceJournal/UI/TrialDetailViewController.swift
+++ b/ScienceJournal/UI/TrialDetailViewController.swift
@@ -1004,7 +1004,7 @@ class TrialDetailViewController: MaterialHeaderViewController,
 
   func imageSelectorDidCreateImageData(_ imageDatas: [ImageData]) {
     guard let imageDataTuple = imageDatas.first else {
-      fatalError("Must have at least one image for [TrialDetailViewController].")
+      fatalError("Must have at least 1 image for [TrialDetailViewController].")
     }
 
     if imageDatas.count > 1 {

--- a/ScienceJournal/UI/TrialDetailViewController.swift
+++ b/ScienceJournal/UI/TrialDetailViewController.swift
@@ -1011,18 +1011,15 @@ class TrialDetailViewController: MaterialHeaderViewController,
       sjlog_info("[TrialDetailViewController] More than 1 ImageData.", category: .general)
     }
 
-    let imageData = imageDataTuple.imageData
-    let metadata = imageDataTuple.metadata
-
     if FeatureFlags.isActionAreaEnabled {
-      createPendingNote(imageData: imageData, imageMetaData: metadata)
+      createPendingNote(imageData: imageDataTuple.imageData, imageMetaData: imageDataTuple.metadata)
       processPendingNote()
 
       // TODO: Consider AA-specific API.
       photoLibraryViewController.navigationController?.popViewController(animated: true)
     } else {
-      pendingNote?.imageData = imageData
-      pendingNote?.imageMetaData = metadata
+      pendingNote?.imageData = imageDataTuple.imageData
+      pendingNote?.imageMetaData = imageDataTuple.metadata
 
       dismiss(animated: true) {
         self.showAddNoteDialog()

--- a/ScienceJournal/UI/TrialDetailViewController.swift
+++ b/ScienceJournal/UI/TrialDetailViewController.swift
@@ -1002,7 +1002,7 @@ class TrialDetailViewController: MaterialHeaderViewController,
 
   // MARK: - ImageSelectorDelegate
 
-  func imageSelectorDidCreateImageData(_ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
+  func imageSelectorDidCreateImageData(_ imageDatas: [ImageData]) {
     guard imageDatas.count == 1, let imageDataTuple = imageDatas.first else {
         fatalError("Only one image can be selected for the trial detail vc.")
     }

--- a/ScienceJournal/UI/TrialDetailViewController.swift
+++ b/ScienceJournal/UI/TrialDetailViewController.swift
@@ -1002,7 +1002,14 @@ class TrialDetailViewController: MaterialHeaderViewController,
 
   // MARK: - ImageSelectorDelegate
 
-  func imageSelectorDidCreateImageData(_ imageData: Data, metadata: NSDictionary?) {
+  func imageSelectorDidCreateImageData(
+    _ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
+    guard imageDatas.count == 1,
+      let imageData = imageDatas.first?.imageData,
+      let metadata = imageDatas.first?.metadata else {
+        fatalError("Only one image can be selected for the trial detail vc.")
+    }
+
     if FeatureFlags.isActionAreaEnabled {
       createPendingNote(imageData: imageData, imageMetaData: metadata)
       processPendingNote()
@@ -1017,11 +1024,6 @@ class TrialDetailViewController: MaterialHeaderViewController,
         self.showAddNoteDialog()
       }
     }
-  }
-
-  func imageSelectorDidCreateMultipleImageDatas(
-    _ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
-    // This view controller does not allow selecting multiple images.
   }
 
   func imageSelectorDidCancel() {

--- a/ScienceJournal/UI/TrialDetailViewController.swift
+++ b/ScienceJournal/UI/TrialDetailViewController.swift
@@ -1002,8 +1002,7 @@ class TrialDetailViewController: MaterialHeaderViewController,
 
   // MARK: - ImageSelectorDelegate
 
-  func imageSelectorDidCreateImageData(
-    _ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
+  func imageSelectorDidCreateImageData(_ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
     guard imageDatas.count == 1,
       let imageData = imageDatas.first?.imageData,
       let metadata = imageDatas.first?.metadata else {

--- a/ScienceJournal/UI/TrialDetailViewController.swift
+++ b/ScienceJournal/UI/TrialDetailViewController.swift
@@ -1003,11 +1003,12 @@ class TrialDetailViewController: MaterialHeaderViewController,
   // MARK: - ImageSelectorDelegate
 
   func imageSelectorDidCreateImageData(_ imageDatas: [(imageData: Data, metadata: NSDictionary?)]) {
-    guard imageDatas.count == 1,
-      let imageData = imageDatas.first?.imageData,
-      let metadata = imageDatas.first?.metadata else {
+    guard imageDatas.count == 1, let imageDataTuple = imageDatas.first else {
         fatalError("Only one image can be selected for the trial detail vc.")
     }
+
+    let imageData = imageDataTuple.imageData
+    let metadata = imageDataTuple.metadata
 
     if FeatureFlags.isActionAreaEnabled {
       createPendingNote(imageData: imageData, imageMetaData: metadata)


### PR DESCRIPTION
Image selection for Experiment cover was broken in a recent update.
Instead of 2 different methods (one for single image and one for multiple), consolidate into one method.
Update all implementers of the previous methods with guards for places where only one image is allowed.

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/google/science-journal-ios/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/google/science-journal-ios/blob/master/CHANGE_LIMITATIONS.md)
